### PR TITLE
Improve entity search performance

### DIFF
--- a/src/main/java/care/smith/top/backend/model/EntityDao.java
+++ b/src/main/java/care/smith/top/backend/model/EntityDao.java
@@ -101,14 +101,6 @@ public class EntityDao {
 
     if (ApiModelMapper.isCategory(entityType)) {
       entity = new Category();
-      if (entityDao.getSubEntities() == null
-          || entityDao.getSubEntities().stream()
-              .noneMatch(e -> ApiModelMapper.isCategory(e.getEntityType())))
-        entity.subCategories(new ArrayList<>());
-      if (entityDao.getSubEntities() == null
-          || entityDao.getSubEntities().stream()
-              .noneMatch(e -> ApiModelMapper.isPhenotype(e.getEntityType())))
-        entity.phenotypes(new ArrayList<>());
     } else {
       entity = new Phenotype();
     }


### PR DESCRIPTION
JSON objects of entities don't contain sub entities, but the respective properties are initialised with empty arrays if there are no sub entities. Currently this is done by iterating sub entities in Java and checking their entity types.

This pull request moves the sub entity check to the database, thus the check is much faster.