### PR TITLE
Update dependency top-phenotypic-query to v0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-phenotypic-query</artifactId>
-            <version>0.5.7</version>
+            <version>0.6.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>care.smith.top</groupId>


### PR DESCRIPTION
v0.5.7 -> v0.6.1

There are no breaking changes