### PR TITLE
Implement abstract query service

### DIFF
--- a/src/main/java/care/smith/top/backend/api/QueryApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/QueryApiDelegateImpl.java
@@ -3,7 +3,6 @@ package care.smith.top.backend.api;
 import care.smith.top.backend.service.PhenotypeQueryService;
 import care.smith.top.backend.util.ApiModelMapper;
 import care.smith.top.model.DataSource;
-import care.smith.top.model.PhenotypeQuery;
 import care.smith.top.model.Query;
 import care.smith.top.model.QueryPage;
 import care.smith.top.model.QueryResult;
@@ -55,8 +54,7 @@ public class QueryApiDelegateImpl implements QueryApiDelegate {
     switch (query.getType()) {
       case PHENOTYPE:
         return new ResponseEntity<>(
-            phenotypeQueryService.enqueueQuery(
-                organisationId, repositoryId, (PhenotypeQuery) query),
+            phenotypeQueryService.enqueueQuery(organisationId, repositoryId, query),
             HttpStatus.CREATED);
       case CONCEPT:
         throw new ResponseStatusException(

--- a/src/main/java/care/smith/top/backend/model/QueryDao.java
+++ b/src/main/java/care/smith/top/backend/model/QueryDao.java
@@ -66,25 +66,25 @@ public class QueryDao {
     this.queryType = Query.TypeEnum.CONCEPT;
   }
 
-  public QueryDao(@NotNull PhenotypeQuery query) {
+  public QueryDao(@NotNull Query query) {
     this.id = query.getId().toString();
     this.name = query.getName();
     this.dataSources = query.getDataSources();
-    this.queryType = Query.TypeEnum.PHENOTYPE;
-    if (query.getCriteria() != null)
-      this.criteria =
-          query.getCriteria().stream().map(QueryCriterionDao::new).collect(Collectors.toList());
-    if (query.getProjection() != null)
-      this.projection =
-          query.getProjection().stream().map(ProjectionEntryDao::new).collect(Collectors.toList());
-  }
 
-  public QueryDao(@NotNull ConceptQuery query) {
-    this.id = query.getId().toString();
-    this.name = query.getName();
-    this.entityId = query.getEntityId();
-    this.dataSources = query.getDataSources();
-    this.queryType = Query.TypeEnum.CONCEPT;
+    if (query instanceof ConceptQuery) {
+      this.queryType = Query.TypeEnum.CONCEPT;
+      this.entityId = ((ConceptQuery) query).getEntityId();
+    } else if (query instanceof PhenotypeQuery) {
+      this.queryType = Query.TypeEnum.PHENOTYPE;
+      if (((PhenotypeQuery) query).getCriteria() != null)
+        this.criteria =
+            ((PhenotypeQuery) query)
+                .getCriteria().stream().map(QueryCriterionDao::new).collect(Collectors.toList());
+      if (((PhenotypeQuery) query).getProjection() != null)
+        this.projection =
+            ((PhenotypeQuery) query)
+                .getProjection().stream().map(ProjectionEntryDao::new).collect(Collectors.toList());
+    }
   }
 
   public String getId() {

--- a/src/main/java/care/smith/top/backend/service/QueryService.java
+++ b/src/main/java/care/smith/top/backend/service/QueryService.java
@@ -1,0 +1,194 @@
+package care.smith.top.backend.service;
+
+import care.smith.top.backend.model.QueryDao;
+import care.smith.top.backend.repository.QueryRepository;
+import care.smith.top.backend.repository.RepositoryRepository;
+import care.smith.top.model.Query;
+import care.smith.top.model.QueryResult;
+import care.smith.top.model.QueryState;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import java.util.logging.Logger;
+import org.jobrunr.jobs.Job;
+import org.jobrunr.jobs.states.StateName;
+import org.jobrunr.scheduling.JobScheduler;
+import org.jobrunr.storage.StorageProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Transactional
+public abstract class QueryService {
+  private final Logger LOGGER = Logger.getLogger(QueryService.class.getName());
+
+  @Value("${spring.paging.page-size:10}")
+  protected int pageSize;
+
+  @Autowired protected JobScheduler jobScheduler;
+  @Autowired protected StorageProvider storageProvider;
+  @Autowired protected QueryRepository queryRepository;
+  @Autowired protected RepositoryRepository repositoryRepository;
+
+  /**
+   * Enqueues the given query to the {@link JobScheduler}.
+   *
+   * @param organisationId ID of the organisation the query belongs to.
+   * @param repositoryId ID of the repository the query belongs to.
+   * @param query The query specification.
+   * @return A {@link QueryResult} that reflects the state immediately after enqueuing.
+   */
+  @PreAuthorize(
+      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
+  public abstract QueryResult enqueueQuery(String organisationId, String repositoryId, Query query);
+
+  /**
+   * Executes a given query without retries.
+   *
+   * @param queryId ID of the query to be executed.
+   */
+  public abstract void executeQuery(UUID queryId);
+
+  /**
+   * Deletes a query. The delete request is propagated to the underlying {@link JobScheduler}.
+   *
+   * <p>If authentication is enabled, users are required to have {@link
+   * care.smith.top.backend.model.Permission#WRITE} permission for the organisation.
+   *
+   * @param organisationId ID of the organisation the query belongs to.
+   * @param repositoryId ID of the repository the query belongs to.
+   * @param queryId ID of the query to be deleted.
+   */
+  @PreAuthorize(
+      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
+  public void deleteQuery(String organisationId, String repositoryId, UUID queryId) {
+    if (!repositoryRepository.existsByIdAndOrganisation_Id(repositoryId, organisationId))
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+
+    QueryDao query =
+        queryRepository
+            .findByRepository_OrganisationIdAndRepositoryIdAndId(
+                organisationId, repositoryId, queryId.toString())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+    try {
+      Job job = storageProvider.getJobById(queryId);
+      storageProvider.deletePermanently(job.getId());
+    } catch (Exception e) {
+      LOGGER.fine(e.getMessage());
+    }
+
+    try {
+      clearResults(
+          query.getRepository().getOrganisation().getId(),
+          query.getRepository().getId(),
+          queryId.toString());
+    } catch (Exception e) {
+      LOGGER.warning(e.getMessage());
+    }
+
+    queryRepository.delete(query);
+  }
+
+  /**
+   * Returns the result description of a query. If the query is still running, the result will only
+   * contain a creation timestamp and a state.
+   *
+   * <p>If authentication is enabled, users are required to have {@link
+   * care.smith.top.backend.model.Permission#WRITE} permission for the organisation.
+   *
+   * @param organisationId ID of the organisation the query belongs to.
+   * @param repositoryId ID of the repository the query belongs to.
+   * @param queryId ID of the query for which a result description is requested.
+   * @return Description of the query's result.
+   */
+  @PreAuthorize(
+      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
+  public QueryResult getQueryResult(String organisationId, String repositoryId, UUID queryId) {
+    if (!repositoryRepository.existsByIdAndOrganisation_Id(repositoryId, organisationId))
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+
+    QueryDao query =
+        queryRepository
+            .findByRepository_OrganisationIdAndRepositoryIdAndId(
+                organisationId, repositoryId, queryId.toString())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+    if (query.getResult() != null) return query.getResult().toApiModel();
+
+    Job job = storageProvider.getJobById(queryId);
+
+    QueryResult queryResult =
+        new QueryResult()
+            .id(queryId)
+            .createdAt(job.getCreatedAt().atOffset(ZoneOffset.UTC))
+            .state(getState(job));
+
+    if (QueryState.FAILED.equals(queryResult.getState()))
+      queryResult.finishedAt(job.getUpdatedAt().atOffset(ZoneOffset.UTC));
+    return queryResult;
+  }
+
+  /**
+   * Returns a page of queries that belong to the given repository.
+   *
+   * <p>If authentication is enabled, users are required to have {@link
+   * care.smith.top.backend.model.Permission#WRITE} permission for the organisation.
+   *
+   * @param organisationId ID of the organisation the repository belongs to.
+   * @param repositoryId ID of the repository for which queries are requested.
+   * @param page Page number, starting at 1.
+   * @return A {@link care.smith.top.model.Page} containing queries.
+   */
+  @PreAuthorize(
+      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
+  public Page<Query> getQueries(String organisationId, String repositoryId, Integer page) {
+    PageRequest pageRequest = PageRequest.of(page == null ? 0 : page - 1, pageSize);
+    return queryRepository
+        .findAllByRepository_OrganisationIdAndRepositoryIdOrderByCreatedAtDesc(
+            organisationId, repositoryId, pageRequest)
+        .map(QueryDao::toApiModel);
+  }
+
+  /**
+   * Deletes all other results related to the given query (such as files in the file system or
+   * additional database records).
+   *
+   * @param organisationId ID of the organisation the query belongs to.
+   * @param repositoryId ID of the repository the query belongs to.
+   * @param queryId ID of the query for which results shall be deleted.
+   * @throws Exception If some result artifacts could not be deleted.
+   */
+  protected abstract void clearResults(String organisationId, String repositoryId, String queryId)
+      throws Exception;
+
+  /**
+   * Extracts the state of a job.
+   *
+   * <p>A {@link Job} uses {@link StateName} to indicate it's state. This state is converted to
+   * {@link QueryState} in the following way:
+   *
+   * <ul>
+   *   <li>{@link StateName#FAILED}, {@link StateName#DELETED} => {@link QueryState#FAILED}
+   *   <li>{@link StateName#SUCCEEDED} => {@link QueryState#FINISHED}
+   *   <li>{@link StateName#PROCESSING} => {@link QueryState#RUNNING}
+   * </ul>
+   *
+   * @param job The job to extract the state from.
+   * @return A {@link QueryState}.
+   */
+  protected QueryState getState(Job job) {
+    if (job.hasState(StateName.FAILED) || job.hasState(StateName.DELETED)) {
+      return QueryState.FAILED;
+    } else if (job.hasState(StateName.SUCCEEDED)) {
+      return QueryState.FINISHED;
+    } else if (job.hasState(StateName.PROCESSING)) {
+      return QueryState.RUNNING;
+    }
+    return QueryState.QUEUED;
+  }
+}

--- a/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
@@ -3,342 +3,83 @@ package care.smith.top.backend.service.nlp;
 import care.smith.top.backend.model.QueryDao;
 import care.smith.top.backend.model.QueryResultDao;
 import care.smith.top.backend.model.RepositoryDao;
-import care.smith.top.backend.repository.QueryRepository;
-import care.smith.top.backend.repository.RepositoryRepository;
 import care.smith.top.backend.repository.nlp.DocumentRepository;
-import care.smith.top.backend.util.ApiModelMapper;
+import care.smith.top.backend.service.QueryService;
 import care.smith.top.model.*;
-import care.smith.top.top_phenotypic_query.converter.csv.CSV;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.FileSystemException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.*;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-import org.jetbrains.annotations.NotNull;
-import org.jobrunr.jobs.Job;
-import org.jobrunr.jobs.states.StateName;
-import org.jobrunr.scheduling.JobScheduler;
-import org.jobrunr.storage.StorageProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
-@Transactional
-public class DocumentQueryService {
-  private static final Logger LOGGER = Logger.getLogger(DocumentQueryService.class.getName());
-
-//  private final CSV csvConverter = new CSV();
-
-  @Value("${spring.paging.page-size:10}")
-  private int pageSize;
+public class DocumentQueryService extends QueryService {
+  private final Logger LOGGER = Logger.getLogger(DocumentQueryService.class.getName());
 
   @Value("${top.documents.data-source-config-dir:config/data_sources/nlp}")
   private String dataSourceConfigDir;
 
-//  @Value("${top.phenotyping.execute-queries:true}")
-//  private boolean executeQueries;
-
-//  @Value("${top.phenotyping.result.dir:config/query_results}")
-//  private String resultDir;
-
-//  @Value("${top.phenotyping.result.download-enabled:true}")
-//  private boolean queryResultDownloadEnabled;
-
-  @Autowired private JobScheduler jobScheduler;
-  @Autowired private StorageProvider storageProvider;
-  @Autowired private QueryRepository queryRepository;
-  @Autowired private RepositoryRepository repositoryRepository;
   @Autowired private DocumentRepository documentRepository;
 
-//  @PreAuthorize(
-//      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
-//  public void deleteQuery(String organisationId, String repositoryId, UUID queryId) {
-//    if (!repositoryRepository.existsByIdAndOrganisation_Id(repositoryId, organisationId))
-//      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-//
-//    QueryDao query =
-//        queryRepository
-//            .findByRepository_OrganisationIdAndRepositoryIdAndId(
-//                organisationId, repositoryId, queryId.toString())
-//            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-//
-//    try {
-//      Job job = storageProvider.getJobById(queryId);
-//      storageProvider.deletePermanently(job.getId());
-//    } catch (Exception e) {
-//      LOGGER.fine(e.getMessage());
-//    }
-//
-//    try {
-//      clearResult(
-//          query.getRepository().getOrganisation().getId(),
-//          query.getRepository().getId(),
-//          queryId.toString());
-//    } catch (IOException e) {
-//      LOGGER.warning(e.getMessage());
-//    }
-//
-//    queryRepository.delete(query);
-//  }
-//
-//  @PreAuthorize(
-//      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
-//  public QueryResult enqueueQuery(String organisationId, String repositoryId, PhenotypeQuery data) {
-//    RepositoryDao repository =
-//        repositoryRepository
-//            .findByIdAndOrganisationId(repositoryId, organisationId)
-//            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-//
-//    if (data == null
-//        || data.getId() == null
-//        || data.getDataSources() == null
-//        || data.getDataSources().isEmpty())
-//      throw new ResponseStatusException(HttpStatus.NOT_ACCEPTABLE);
-//
-//    UUID queryId = data.getId();
-//
-//    if (queryRepository.existsById(queryId.toString()))
-//      throw new ResponseStatusException(HttpStatus.CONFLICT);
-//
-//    if (getConfigs(data.getDataSources()).isEmpty())
-//      throw new ResponseStatusException(HttpStatus.NOT_ACCEPTABLE);
-//
-//    jobScheduler.enqueue(queryId, () -> this.executeQuery(queryId));
-//    queryRepository.save(new QueryDao(data).repository(repository));
-//
-//    return getQueryResult(organisationId, repositoryId, queryId);
-//  }
-//
-//  @org.jobrunr.jobs.annotations.Job(name = "Document query", retries = 0)
-//  public void executeQuery(UUID queryId) {
-//    OffsetDateTime createdAt = OffsetDateTime.now();
-//    QueryDao queryDao =
-//        queryRepository
-//            .findById(queryId.toString())
-//            .orElseThrow(
-//                () ->
-//                    new NullPointerException(
-//                        String.format("Query with ID %s does not exist.", queryId)));
-//
-//    LOGGER.info(
-//        String.format(
-//            "Running document query '%s' for repository '%s'...",
-//            queryId, queryDao.getRepository().getDisplayName()));
-//
-//    ConceptQuery query = (ConceptQuery) queryDao.toApiModel();
-//    List<DataAdapterConfig> configs = getConfigs(query.getDataSources());
-//
-//    // TODO: only one data source supported yet
-//    DataAdapterConfig config = configs.stream().findFirst().orElseThrow();
-//
-//    QueryResultDao result;
-//    try {
-//      ResultSet rs;
-//      if (executeQueries) {
-//        DataAdapter adapter = DataAdapter.getInstance(config);
-//        if (adapter == null) throw new NullPointerException("Adaptor type could not be derived.");
-//
-//        PhenotypeFinder finder = new PhenotypeFinder(query, phenotypes, adapter);
-//        rs = finder.execute();
-//        adapter.close();
-//        result =
-//            new QueryResultDao(
-//                queryDao, createdAt, (long) rs.size(), OffsetDateTime.now(), QueryState.FINISHED);
-//      } else {
-//        rs = new ResultSet();
-//        result =
-//            new QueryResultDao(queryDao, createdAt, 0L, OffsetDateTime.now(), QueryState.FINISHED)
-//                .message("Query execution is disabled.");
-//      }
-//
-//      storeResult(
-//          queryDao.getRepository().getOrganisation().getId(),
-//          queryDao.getRepository().getId(),
-//          queryId.toString(),
-//          rs,
-//          phenotypes);
-//    } catch (Throwable e) {
-//      e.printStackTrace();
-//      result =
-//          new QueryResultDao(queryDao, createdAt, null, OffsetDateTime.now(), QueryState.FAILED)
-//              .message("Cause: " + (e.getMessage() != null ? e.getMessage() : e.toString()));
-//    }
-//
-//    queryDao.result(result);
-//    queryRepository.save(queryDao);
-//  }
-//
-//  public Optional<DataAdapterConfig> getDataAdapterConfig(String id) {
-//    if (id == null) return Optional.empty();
-//    return getDataAdapterConfigs().stream().filter(a -> id.equals(a.getId())).findFirst();
-//  }
-//
-//  @PreAuthorize(
-//      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
-//  public QueryResult getQueryResult(String organisationId, String repositoryId, UUID queryId) {
-//    if (!repositoryRepository.existsByIdAndOrganisation_Id(repositoryId, organisationId))
-//      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-//
-//    QueryDao query =
-//        queryRepository
-//            .findByRepository_OrganisationIdAndRepositoryIdAndId(
-//                organisationId, repositoryId, queryId.toString())
-//            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-//
-//    if (query.getResult() != null) return query.getResult().toApiModel();
-//
-//    Job job = storageProvider.getJobById(queryId);
-//
-//    QueryResult queryResult =
-//        new QueryResult()
-//            .id(queryId)
-//            .createdAt(job.getCreatedAt().atOffset(ZoneOffset.UTC))
-//            .state(getState(job));
-//
-//    if (QueryState.FAILED.equals(queryResult.getState()))
-//      queryResult.finishedAt(job.getUpdatedAt().atOffset(ZoneOffset.UTC));
-//    return queryResult;
-//  }
-//
-//  @PreAuthorize(
-//      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
-//  public Path getQueryResultPath(String organisationId, String repositoryId, UUID queryId)
-//      throws FileSystemException {
-//    if (!queryResultDownloadEnabled)
-//      throw new ResponseStatusException(HttpStatus.NOT_ACCEPTABLE, "Query result download is disabled.");
-//    if (!repositoryRepository.existsByIdAndOrganisation_Id(repositoryId, organisationId))
-//      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Repository does not exist.");
-//
-//    QueryDao query =
-//        queryRepository
-//            .findByRepository_OrganisationIdAndRepositoryIdAndId(
-//                organisationId, repositoryId, queryId.toString())
-//            .orElseThrow(
-//                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Query does not exist."));
-//
-//    if (query.getResult() == null)
-//      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Query has no result.");
-//
-//    Path queryPath =
-//        Paths.get(resultDir, organisationId, repositoryId, String.format("%s.zip", queryId));
-//    if (!queryPath.startsWith(Paths.get(resultDir)))
-//      throw new FileSystemException("Repository directory isn't a child of the results directory.");
-//
-//    return queryPath;
-//  }
-//
-//  public List<DataAdapterConfig> getDataAdapterConfigs() {
-//    try (Stream<Path> paths = Files.list(Path.of(dataSourceConfigDir))) {
-//      return paths
-//          .map(this::toDataAdapterConfig)
-//          .filter(Objects::nonNull)
-//          .sorted(Comparator.comparing(DataAdapterConfig::getId))
-//          .collect(Collectors.toList());
-//    } catch (Exception e) {
-//      LOGGER.warning(
-//          String.format("Could not load data adapter configs from dir '%s'.", dataSourceConfigDir));
-//    }
-//    return Collections.emptyList();
-//  }
-//
-//  public List<DataSource> getDataSources() {
-//    return getDataAdapterConfigs().stream()
-//        .map(a -> new DataSource().id(a.getId()).title(a.getId().replace('_', ' ')))
-//        .sorted(Comparator.comparing(DataSource::getId))
-//        .collect(Collectors.toList());
-//  }
-//
-//  @PreAuthorize(
-//      "hasPermission(#organisationId, 'care.smith.top.backend.model.OrganisationDao', 'WRITE')")
-//  public Page<Query> getQueries(String organisationId, String repositoryId, Integer page) {
-//    PageRequest pageRequest = PageRequest.of(page == null ? 0 : page - 1, pageSize);
-//    return queryRepository
-//        .findAllByRepository_OrganisationIdAndRepositoryIdOrderByCreatedAtDesc(
-//            organisationId, repositoryId, pageRequest)
-//        .map(QueryDao::toApiModel);
-//  }
-//
-//  private void clearResult(String organisationId, String repositoryId, String queryId)
-//      throws IOException {
-//    Path queryPath =
-//        Paths.get(resultDir, organisationId, repositoryId, String.format("%s.zip", queryId));
-//    if (!queryPath.startsWith(Paths.get(resultDir)))
-//      LOGGER.severe(String.format("Query file '%s' is invalid and cannot be deleted!", queryPath));
-//    Files.deleteIfExists(queryPath);
-//  }
-//
-//  @NotNull
-//  private List<DataAdapterConfig> getConfigs(List<String> dataSources) {
-//    return dataSources.stream()
-//        .map(s -> getDataAdapterConfig(s).orElse(null))
-//        .filter(Objects::nonNull)
-//        .collect(Collectors.toList());
-//  }
-//
-//  private QueryState getState(Job job) {
-//    if (job.hasState(StateName.FAILED) || job.hasState(StateName.DELETED)) {
-//      return QueryState.FAILED;
-//    } else if (job.hasState(StateName.SUCCEEDED)) {
-//      return QueryState.FINISHED;
-//    } else if (job.hasState(StateName.PROCESSING)) {
-//      return QueryState.RUNNING;
-//    }
-//    return QueryState.QUEUED;
-//  }
-//
-//  private void storeResult(
-//      String organisationId,
-//      String repositoryId,
-//      String queryId,
-//      ResultSet resultSet,
-//      Entity[] phenotypes)
-//      throws IOException {
-//    Path repositoryPath = Paths.get(resultDir, organisationId, repositoryId);
-//    if (!repositoryPath.startsWith(Paths.get(resultDir)))
-//      throw new FileSystemException("Repository directory isn't a child of the results directory.");
-//
-//    Files.createDirectories(repositoryPath);
-//    File zipFile =
-//        Files.createFile(repositoryPath.resolve(String.format("%s.zip", queryId))).toFile();
-//    ZipOutputStream zipStream = new ZipOutputStream(new FileOutputStream(zipFile));
-//
-//    zipStream.putNextEntry(new ZipEntry("data.csv"));
-//    csvConverter.write(resultSet, zipStream);
-//
-//    zipStream.putNextEntry(new ZipEntry("metadata.csv"));
-//    csvConverter.write(phenotypes, zipStream);
-//
-//    zipStream.close();
-//  }
-//
-//  private DataAdapterConfig toDataAdapterConfig(Path path) {
-//    try {
-//      DataAdapterConfig dataAdapterConfig = DataAdapterConfig.getInstance(path.toString());
-//      return dataAdapterConfig.getId() == null ? null : dataAdapterConfig;
-//    } catch (Exception e) {
-//      LOGGER.warning(
-//          String.format(
-//              "Data adapter config could not be loaded from file '%s'. Error: %s",
-//              path.toString(), e.getMessage()));
-//    }
-//    return null;
-//  }
+  @Override
+  @org.jobrunr.jobs.annotations.Job(name = "Document query", retries = 0)
+  public void executeQuery(UUID queryId) {
+    OffsetDateTime createdAt = OffsetDateTime.now();
+    QueryDao queryDao =
+        queryRepository
+            .findById(queryId.toString())
+            .orElseThrow(
+                () ->
+                    new NullPointerException(
+                        String.format("Query with ID %s does not exist.", queryId)));
+
+    LOGGER.info(
+        String.format(
+            "Running %s query '%s' for repository '%s'...",
+            getClass().getSimpleName(), queryId, queryDao.getRepository().getDisplayName()));
+
+    ConceptQuery query = (ConceptQuery) queryDao.toApiModel();
+
+    // TODO: implement query logic
+
+    QueryResultDao result =
+        new QueryResultDao(queryDao, createdAt, 0L, OffsetDateTime.now(), QueryState.FINISHED);
+
+    queryDao.result(result);
+    queryRepository.save(queryDao);
+  }
+
+  @Override
+  public QueryResult enqueueQuery(String organisationId, String repositoryId, Query query) {
+    if (!(query instanceof ConceptQuery))
+      throw new ResponseStatusException(
+          HttpStatus.NOT_ACCEPTABLE, "The provided query is not a concept query!");
+
+    RepositoryDao repository =
+        repositoryRepository
+            .findByIdAndOrganisationId(repositoryId, organisationId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+    if (query.getId() == null || query.getDataSources() == null || query.getDataSources().isEmpty())
+      throw new ResponseStatusException(HttpStatus.NOT_ACCEPTABLE);
+
+    UUID queryId = query.getId();
+
+    if (queryRepository.existsById(queryId.toString()))
+      throw new ResponseStatusException(HttpStatus.CONFLICT);
+
+    // TODO: create any prerequisites
+
+    queryRepository.save(new QueryDao(query).repository(repository));
+    jobScheduler.enqueue(queryId, () -> this.executeQuery(queryId));
+
+    return getQueryResult(organisationId, repositoryId, queryId);
+  }
+
+  @Override
+  protected void clearResults(String organisationId, String repositoryId, String queryId)
+      throws Exception {}
 }


### PR DESCRIPTION
Extracted as many logic from the individual query services as possible.

Sadly the method `enqueueQuery()` cannot be extracted into the new abstract class `QueryService`, because Jobrunr would fail to resolve the `executeQuery()` method.