### PR TITLE
Set liquibase log level to warning

### DIFF
--- a/src/main/resources/liquibase.properties
+++ b/src/main/resources/liquibase.properties
@@ -3,3 +3,4 @@ url=jdbc:hsqldb:file:config/db/local
 driver=org.hsqldb.jdbcDriver
 referenceUrl=hibernate:spring:care.smith.top.backend.model?dialect=org.hibernate.dialect.HSQLDialect&hibernate.physical_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy&hibernate.implicit_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
 referenceDriver=liquibase.ext.hibernate.database.connection.HibernateDriver
+logLevel=warning


### PR DESCRIPTION
Right now it is extremely verbose.
See <https://docs.liquibase.com/concepts/connections/creating-config-properties.html>.
Partly addresses #176.