### PR TITLE
100 times Docker build speedup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM maven:3-openjdk-11-slim AS build-stage
 ARG GH_MAVEN_PKG_USER
 ARG GH_MAVEN_PKG_AUTH_TOKEN
@@ -6,7 +7,7 @@ ENV GH_MAVEN_PKG_AUTH_TOKEN=$GH_MAVEN_PKG_AUTH_TOKEN
 WORKDIR /app
 COPY . .
 COPY .mvn-ci.xml /root/.m2/settings.xml
-RUN mvn package -B -DskipTests=true
+RUN --mount=type=cache,target=/root/.m2/repository mvn package -B -DskipTests=true
 
 FROM openjdk:11-jdk-slim AS production-stage
 COPY --from=build-stage /app/target/*.jar /usr/src/top-backend/top-backend.jar


### PR DESCRIPTION
Right now a Docker build command has to redownload the dependencies on any code change.
On an admittedly low performance i3-1115G4 on wireless with a 50 MBit connection this takes more than 15 minutes to build even though the image was built before and only a single comment was added:

```
backend$ docker build . -t top-backend --build-arg GH_MAVEN_PKG_USER=konradhoeffner --build-arg GH_MAVEN_PKG_AUTH_TOKEN=...                                                              pr-docker-cache
[+] Building 1152.4s (16/16) FINISHED                                                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 715B                                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.2s
 => => transferring context: 58B                                                                                                                                                                                                         0.0s
 => resolve image config for docker.io/docker/dockerfile:1                                                                                                                                                                               2.3s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:ac85f380a63b13dfcefa89046420e1781752bab202122f8f50032edf31be0021                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/openjdk:11-jdk-slim                                                                                                                                                                   1.9s
 => [internal] load metadata for docker.io/library/maven:3-openjdk-11-slim                                                                                                                                                               1.5s
 => [build-stage 1/5] FROM docker.io/library/maven:3-openjdk-11-slim@sha256:2cb7c73ba2fd0f7ae64cfabd99180030ec85841a1197b4ae821d21836cb0aa3b                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 17.75kB                                                                                                                                                                                                     0.0s
 => CACHED [production-stage 1/3] FROM docker.io/library/openjdk:11-jdk-slim@sha256:868a4f2151d38ba6a09870cec584346a5edc8e9b71fde275eb2e0625273e2fd8                                                                                     0.0s
 => CACHED [build-stage 2/5] WORKDIR /app                                                                                                                                                                                                0.0s
 => [build-stage 3/5] COPY . .                                                                                                                                                                                                           0.1s
 => [build-stage 4/5] COPY .mvn-ci.xml /root/.m2/settings.xml                                                                                                                                                                            0.0s
 => [build-stage 5/5] RUN mvn package -B -DskipTests=true                                                                                                                                                                             1146.0s
 => [production-stage 2/3] COPY --from=build-stage /app/target/*.jar /usr/src/top-backend/top-backend.jar                                                                                                                                0.1s 
 => [production-stage 3/3] WORKDIR /usr/src/top-backend                                                                                                                                                                                  0.1s 
 => exporting to image                                                                                                                                                                                                                   1.0s 
 => => exporting layers                                                                                                                                                                                                                  1.0s 
 => => writing image sha256:bdde28baf8a462cbdf99efc3733e69dc94cafe4b3cfe79815e452ebae9b7a34f                                                                                                                                             0.0s 
 => => naming to docker.io/library/top-backend                                                                                                                                                                                           0.0s 
```

This PR caches the /root/.m2/repository (normally I would cache `/root/.m2` but I think this could overwrite the settings.xml copied above) directory and reduces build time by a factor of more than 100:

```
backend$ docker build . -t top-backend --build-arg GH_MAVEN_PKG_USER=konradhoeffner --build-arg GH_MAVEN_PKG_AUTH_TOKEN=...                                                              pr-docker-cache
[+] Building 10.1s (16/16) FINISHED                                                                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 678B                                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.2s
 => => transferring context: 58B                                                                                                                                                                                                         0.0s
 => resolve image config for docker.io/docker/dockerfile:1                                                                                                                                                                               1.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:ac85f380a63b13dfcefa89046420e1781752bab202122f8f50032edf31be0021                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/openjdk:11-jdk-slim                                                                                                                                                                   0.8s
 => [internal] load metadata for docker.io/library/maven:3-openjdk-11-slim                                                                                                                                                               0.8s
 => [build-stage 1/5] FROM docker.io/library/maven:3-openjdk-11-slim@sha256:2cb7c73ba2fd0f7ae64cfabd99180030ec85841a1197b4ae821d21836cb0aa3b                                                                                             0.0s
 => CACHED [production-stage 1/3] FROM docker.io/library/openjdk:11-jdk-slim@sha256:868a4f2151d38ba6a09870cec584346a5edc8e9b71fde275eb2e0625273e2fd8                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 17.07kB                                                                                                                                                                                                     0.0s
 => CACHED [build-stage 2/5] WORKDIR /app                                                                                                                                                                                                0.0s
 => [build-stage 3/5] COPY . .                                                                                                                                                                                                           0.1s
 => [build-stage 4/5] COPY .mvn-ci.xml /root/.m2/settings.xml                                                                                                                                                                            0.1s
 => [build-stage 5/5] RUN --mount=type=cache,target=/root/.m2/repository mvn package -B -DskipTests=true                                                                                                                                 6.7s
 => [production-stage 2/3] COPY --from=build-stage /app/target/*.jar /usr/src/top-backend/top-backend.jar                                                                                                                                0.2s 
 => [production-stage 3/3] WORKDIR /usr/src/top-backend                                                                                                                                                                                  0.1s 
 => exporting to image                                                                                                                                                                                                                   0.5s 
 => => exporting layers                                                                                                                                                                                                                  0.5s 
 => => writing image sha256:ddd36119c033ef47bf749fc4cb63ccbb2df3751408f364ee92dce1933d632933                                                                                                                                             0.0s 
 => => naming to docker.io/library/top-backend                                                                                                                                                                                           0.0s 
```