### PR TITLE
Add startup routine that imports demo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ for additional documentation.
     * `QUERY_RESULT_DOWNLOAD_ENABLED`: whether users with write permission for a repository can download query results
       or not, defaults to true
     * `TERMINOLOGY_SERVICE_ENDPOINT`: endpoint of the Ontology Lookup Service to be used for code search, defaults
-      to https://www.ebi.ac.uk/ols4/api (OLS4 is currently supported)  
+      to https://www.ebi.ac.uk/ols4/api (OLS4 is currently supported)
+    * `IMPORT_DEMO_DATA`: whether a demo organisation with a small BMI phenotype model should be imported on startup,
+      defaults to false
 
    Document related:  
    *(The following variables will be overwritten by their respective adapter values if specified)*  

--- a/src/main/java/care/smith/top/backend/util/DemoDataImporter.java
+++ b/src/main/java/care/smith/top/backend/util/DemoDataImporter.java
@@ -1,0 +1,86 @@
+package care.smith.top.backend.util;
+
+import care.smith.top.backend.configuration.AuthenticatedUser;
+import care.smith.top.backend.model.jpa.UserDao;
+import care.smith.top.backend.service.EntityService;
+import care.smith.top.backend.service.OrganisationService;
+import care.smith.top.backend.service.RepositoryService;
+import care.smith.top.backend.service.UserService;
+import care.smith.top.model.Organisation;
+import care.smith.top.model.Repository;
+import care.smith.top.model.RepositoryType;
+import java.util.logging.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DemoDataImporter {
+  private final Logger LOGGER = Logger.getLogger(DemoDataImporter.class.getName());
+  @Autowired OrganisationService organisationService;
+  @Autowired RepositoryService repositoryService;
+  @Autowired EntityService entityService;
+  @Autowired UserService userService;
+
+  @Value("${top.demo-data:false}")
+  private boolean importDemoData;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void init() {
+    if (!importDemoData) return;
+    LOGGER.fine("Importing demo data...");
+    try {
+      importData();
+    } catch (Exception e) {
+      LOGGER.fine("Demo data import failed! " + e.getMessage());
+    }
+  }
+
+  @Transactional
+  private void importData() {
+    UserDao demoUser = buildDemoUser();
+    SecurityContextHolder.getContext().setAuthentication(new AuthenticatedUser(demoUser));
+
+    Organisation demoOrganisation =
+        new Organisation()
+            .id("demo-organisation")
+            .name("Demo Organisation")
+            .description("This is a demo organisation with a sample repository to get started!");
+    organisationService.createOrganisation(demoOrganisation);
+    LOGGER.finer("Demo organisation imported.");
+
+    Repository demoRepository =
+        new Repository()
+            .id("demo-repository")
+            .organisation(demoOrganisation)
+            .repositoryType(RepositoryType.PHENOTYPE_REPOSITORY)
+            .primary(true)
+            .name("Demo Repository")
+            .description(
+                "This repository contains a simple phenotype model for reasoning about BMI.");
+    repositoryService.createRepository(demoOrganisation.getId(), demoRepository, null);
+    LOGGER.finer("Demo repository imported.");
+
+    entityService.importRepository(
+        demoOrganisation.getId(),
+        demoRepository.getId(),
+        TopJsonFormat.class.getSimpleName(),
+        DemoDataImporter.class.getResourceAsStream("/demo-data.json"));
+    LOGGER.finer("Demo phenotypes imported.");
+  }
+
+  private UserDao buildDemoUser() {
+    Jwt jwt =
+        Jwt.withTokenValue("dummy-token")
+            .claim("sub", "demo-user")
+            .claim("name", "Demo User")
+            .header("Accept", "application/json")
+            .build();
+    return userService.getOrCreateUser(jwt).orElse(null);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,7 @@ org:
 top:
   appName: '@project.name@'
   version: '@project.version@'
+  demo-data: ${IMPORT_DEMO_DATA:false}
   result:
     dir: ${QUERY_RESULT_DIR:config/query_results}
     download-enabled: ${QUERY_RESULT_DOWNLOAD_ENABLED:true}

--- a/src/main/resources/demo-data.json
+++ b/src/main/resources/demo-data.json
@@ -1,0 +1,533 @@
+[
+  {
+    "entityType": "single_restriction",
+    "id": "demo-weight-100",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "≥ 100 Kilogramm"
+      },
+      {
+        "lang": "en",
+        "text": "≥ 100 kilogram"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "number",
+      "quantifier": "min",
+      "cardinality": 1,
+      "minOperator": ">=",
+      "values": [
+        100,
+        null
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "single_phenotype",
+      "id": "demo-weight"
+    }
+  },
+  {
+    "entityType": "single_restriction",
+    "id": "demo-height-150",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "≥ 150 Centimeter"
+      },
+      {
+        "lang": "en",
+        "text": "≥ 150 centimeters"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "number",
+      "quantifier": "min",
+      "cardinality": 1,
+      "minOperator": ">=",
+      "values": [
+        150,
+        null
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "single_phenotype",
+      "id": "demo-height"
+    }
+  },
+  {
+    "entityType": "single_phenotype",
+    "id": "demo-height",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "Größe"
+      },
+      {
+        "lang": "en",
+        "text": "Height"
+      }
+    ],
+    "synonyms": [
+      {
+        "lang": "de",
+        "text": "Länge"
+      },
+      {
+        "lang": "en",
+        "text": "Length"
+      }
+    ],
+    "descriptions": [],
+    "codes": [
+      {
+        "uri": "http://loinc.org/3137-7",
+        "codeSystem": {
+          "uri": "http://loinc.org",
+          "name": "Logical Observation Identifier Names and Codes",
+          "shortName": "LOINC",
+          "externalId": "loinc"
+        },
+        "code": "3137-7",
+        "scope": "self",
+        "name": "Body height Measured"
+      },
+      {
+        "uri": "http://loinc.org/8302-2",
+        "codeSystem": {
+          "uri": "http://loinc.org",
+          "name": "Logical Observation Identifier Names and Codes",
+          "shortName": "LOINC",
+          "externalId": "loinc"
+        },
+        "code": "8302-2",
+        "scope": "self",
+        "name": "Body height"
+      }
+    ],
+    "superCategories": [],
+    "dataType": "number",
+    "itemType": "observation",
+    "unit": "cm"
+  },
+  {
+    "entityType": "single_phenotype",
+    "id": "demo-age",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "Alter"
+      },
+      {
+        "lang": "en",
+        "text": "Age"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [
+      {
+        "uri": "http://loinc.org/30525-0",
+        "codeSystem": {
+          "uri": "http://loinc.org",
+          "name": "Logical Observation Identifier Names and Codes",
+          "shortName": "LOINC",
+          "externalId": "loinc"
+        },
+        "code": "30525-0",
+        "scope": "self",
+        "name": "Age"
+      }
+    ],
+    "superCategories": [],
+    "dataType": "number",
+    "itemType": "subject_age",
+    "unit": "a"
+  },
+  {
+    "entityType": "single_phenotype",
+    "id": "demo-sex",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "Geschlecht"
+      },
+      {
+        "lang": "en",
+        "text": "Sex"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [
+      {
+        "uri": "http://loinc.org/46098-0",
+        "codeSystem": {
+          "uri": "http://loinc.org",
+          "name": "Logical Observation Identifier Names and Codes",
+          "shortName": "LOINC",
+          "externalId": "loinc"
+        },
+        "code": "46098-0",
+        "scope": "self",
+        "name": "Sex"
+      }
+    ],
+    "superCategories": [],
+    "dataType": "string",
+    "itemType": "subject_sex"
+  },
+  {
+    "entityType": "single_phenotype",
+    "id": "demo-weight",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "Gewicht"
+      },
+      {
+        "lang": "en",
+        "text": "Weight"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [
+      {
+        "uri": "http://loinc.org/3141-9",
+        "codeSystem": {
+          "uri": "http://loinc.org",
+          "name": "Logical Observation Identifier Names and Codes",
+          "shortName": "LOINC",
+          "externalId": "loinc"
+        },
+        "code": "3141-9",
+        "scope": "self",
+        "name": "Body weight Measured"
+      }
+    ],
+    "superCategories": [],
+    "dataType": "number",
+    "itemType": "observation",
+    "unit": "kg"
+  },
+  {
+    "entityType": "single_restriction",
+    "id": "demo-sex-female",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "Weiblich"
+      },
+      {
+        "lang": "en",
+        "text": "Female"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "string",
+      "quantifier": "min",
+      "cardinality": 1,
+      "values": [
+        "female"
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "single_phenotype",
+      "id": "demo-sex"
+    }
+  },
+  {
+    "entityType": "single_restriction",
+    "id": "demo-age-18-below",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "< 18 Jahre"
+      },
+      {
+        "lang": "en",
+        "text": "< 18 years"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "number",
+      "quantifier": "min",
+      "cardinality": 1,
+      "maxOperator": "<",
+      "values": [
+        null,
+        18
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "single_phenotype",
+      "id": "demo-age"
+    }
+  },
+  {
+    "entityType": "single_restriction",
+    "id": "demo-age-18-above",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "≥ 18 Jahre"
+      },
+      {
+        "lang": "en",
+        "text": "≥ 18 years"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "number",
+      "quantifier": "min",
+      "cardinality": 1,
+      "minOperator": ">=",
+      "values": [
+        18,
+        null
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "single_phenotype",
+      "id": "demo-age"
+    }
+  },
+  {
+    "entityType": "composite_restriction",
+    "id": "demo-bmi-25-30",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "25-30"
+      },
+      {
+        "lang": "en",
+        "text": "25-30"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "number",
+      "quantifier": "min",
+      "cardinality": 1,
+      "minOperator": ">=",
+      "maxOperator": "<",
+      "values": [
+        25,
+        30
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "composite_phenotype",
+      "id": "demo-bmi"
+    }
+  },
+  {
+    "entityType": "composite_restriction",
+    "id": "demo-bmi-27-30",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "27-30"
+      },
+      {
+        "lang": "en",
+        "text": "27-30"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "number",
+      "quantifier": "min",
+      "cardinality": 1,
+      "minOperator": ">=",
+      "maxOperator": "<",
+      "values": [
+        27,
+        30
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "composite_phenotype",
+      "id": "demo-bmi"
+    }
+  },
+  {
+    "entityType": "composite_phenotype",
+    "id": "demo-bmi",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "BMI"
+      },
+      {
+        "lang": "en",
+        "text": "BMI"
+      }
+    ],
+    "synonyms": [
+      {
+        "lang": "de",
+        "text": "Körper-Masse-Index"
+      },
+      {
+        "lang": "en",
+        "text": "Body mass index"
+      }
+    ],
+    "descriptions": [],
+    "codes": [
+      {
+        "uri": "https://loinc.org/39156-5",
+        "codeSystem": {
+          "uri": "http://loinc.org",
+          "name": "Logical Observation Identifier Names and Codes",
+          "shortName": "LOINC",
+          "externalId": "loinc"
+        },
+        "code": "39156-5",
+        "scope": "self",
+        "name": "Body mass index"
+      }
+    ],
+    "superCategories": [],
+    "dataType": "number",
+    "expression": {
+      "functionId": "Divide",
+      "arguments": [
+        {
+          "entityId": "demo-weight",
+          "arguments": [],
+          "values": []
+        },
+        {
+          "functionId": "Power",
+          "arguments": [
+            {
+              "functionId": "Divide",
+              "arguments": [
+                {
+                  "entityId": "demo-height",
+                  "arguments": [],
+                  "values": []
+                },
+                {
+                  "arguments": [],
+                  "values": [
+                    {
+                      "dataType": "number",
+                      "value": 100
+                    }
+                  ]
+                }
+              ],
+              "values": []
+            },
+            {
+              "arguments": [],
+              "values": [
+                {
+                  "dataType": "number",
+                  "value": 2
+                }
+              ]
+            }
+          ],
+          "values": []
+        }
+      ],
+      "values": []
+    },
+    "unit": "kg/m2"
+  },
+  {
+    "entityType": "single_restriction",
+    "id": "demo-male",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "Männlich"
+      },
+      {
+        "lang": "en",
+        "text": "Male"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "string",
+      "quantifier": "min",
+      "cardinality": 1,
+      "values": [
+        "male"
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "single_phenotype",
+      "id": "demo-sex"
+    }
+  },
+  {
+    "entityType": "composite_restriction",
+    "id": "demo-bmi-30-35",
+    "titles": [
+      {
+        "lang": "de",
+        "text": "30-35"
+      },
+      {
+        "lang": "en",
+        "text": "30-35"
+      }
+    ],
+    "synonyms": [],
+    "descriptions": [],
+    "codes": [],
+    "dataType": "boolean",
+    "restriction": {
+      "type": "number",
+      "quantifier": "min",
+      "cardinality": 1,
+      "minOperator": ">=",
+      "maxOperator": "<",
+      "values": [
+        30,
+        35
+      ]
+    },
+    "superPhenotype": {
+      "entityType": "composite_phenotype",
+      "id": "demo-bmi"
+    }
+  }
+]


### PR DESCRIPTION
* introduces a new env var `IMPORT_DEMO_DATA` (boolean)
* if true, a demo organisation and a repository are created
* the repository contains some BMI related phenotypes

## Limitations
1. The demo data only consists of a simple phenotype model. No adaptor or data source is created.
2. If the demo organisation is deleted, it will automatically be recreated on the next start up, if `IMPORT_DEMO_DATA` is not set to false.
3. If Oauth2 is enabled, a dummy user 'demo-user' will be created to perform the import. The demo user will have manage privileges for the demo organisation.