### PR TITLE
Concept pipeline json config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-api</artifactId>
-            <version>0.10.0</version>
+            <version>0.10.1</version>
         </dependency>
         <dependency>
             <groupId>care.smith.top</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>care.smith.top</groupId>
     <artifactId>top-backend</artifactId>
-    <version>0.7.3</version>
+    <version>0.7.4</version>
     <packaging>jar</packaging>
 
     <name>TOP Backend</name>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-api</artifactId>
-            <version>0.10.1</version>
+            <version>0.10.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>care.smith.top</groupId>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-document-query</artifactId>
-            <version>0.8.0</version>
+            <version>0.8.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>care.smith.top</groupId>
@@ -151,6 +151,11 @@
             <artifactId>jakarta.json-api</artifactId>
             <version>2.0.1</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20240303</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-api</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>0.10.1</version>
         </dependency>
         <dependency>
             <groupId>care.smith.top</groupId>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-document-query</artifactId>
-            <version>0.8.1-SNAPSHOT</version>
+            <version>0.8.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>care.smith.top</groupId>

--- a/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
@@ -84,6 +84,11 @@ public class ConceptPipelineApiDelegateImpl implements ConceptPipelineApiDelegat
   }
 
   @Override
+  public ResponseEntity<Object> getConceptGraphPipelineConfiguration(String pipelineId) {
+    throw new NotImplementedException();
+  }
+
+  @Override
   public ResponseEntity<PipelineResponse> startConceptGraphPipelineWithJson(
       ConceptPipelineConfigRequest conceptPipelineConfigRequest) {
     throw new NotImplementedException();

--- a/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
@@ -87,7 +87,9 @@ public class ConceptPipelineApiDelegateImpl implements ConceptPipelineApiDelegat
 
   @Override
   public ResponseEntity<String> getConceptGraphPipelineConfiguration(String pipelineId) {
-    throw new NotImplementedException();
+    String config = conceptGraphsService.getPipelineConfig(pipelineId);
+    if (Objects.equals(config, "{}")) return ResponseEntity.notFound().build();
+    return ResponseEntity.of(Optional.ofNullable(config));
   }
 
   @Override

--- a/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
@@ -89,7 +89,9 @@ public class ConceptPipelineApiDelegateImpl implements ConceptPipelineApiDelegat
   public ResponseEntity<String> getConceptGraphPipelineConfiguration(String pipelineId) {
     String config = conceptGraphsService.getPipelineConfig(pipelineId);
     if (Objects.equals(config, "{}")) return ResponseEntity.notFound().build();
-    return ResponseEntity.of(Optional.ofNullable(config));
+    JSONObject jsonObject = new JSONObject(config);
+    String configStr = jsonObject.has("config")? jsonObject.get("config").toString() : "{}";
+    return ResponseEntity.of(Optional.ofNullable(configStr));
   }
 
   @Override

--- a/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
@@ -223,6 +223,12 @@ public class ConceptPipelineApiDelegateImpl implements ConceptPipelineApiDelegat
     }
   }
 
+  @Override
+  public ResponseEntity<Void> stopConceptGraphPipeline(String pipelineId) {
+    PipelineResponse pipelineResponse = conceptGraphsService.stopPipeline(pipelineId);
+    return ResponseEntity.ok().build();
+  }
+
   private Map<String, String> createDocumentServerConfigMap(TextAdapterConfig textAdapterConfig) {
     // ToDO: index right now in the concept graphs api only supports one value
     Map<String, String> configMap = new HashMap<>(Map.of(

--- a/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/nlp/ConceptPipelineApiDelegateImpl.java
@@ -99,7 +99,7 @@ public class ConceptPipelineApiDelegateImpl implements ConceptPipelineApiDelegat
       String conceptPipelineConfigRequest) {
     PipelineResponse pipelineResponse;
     //ToDo: Attention! skip_present & return_statistics need to be put into the json as well (so it's not the same json as from concept-graphs-api)
-    JSONObject request = new JSONObject(conceptPipelineConfigRequest);
+    JSONObject request = new JSONObject(conceptPipelineConfigRequest.replace("\\",""));
     HashMap<String, String> requestParams = new HashMap<>(Map.of(
         "name", "default",
         "language", "en"

--- a/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
@@ -11,6 +11,8 @@ import java.io.File;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -91,6 +93,17 @@ public class ConceptGraphsService implements ContentService {
     PipelineResponseEntity pre =
         pipelineManager.startPipeline(
             data, configs, labels, processName, language, skipPresent, returnStatistics);
+    return addStatusToPipelineResponse(pre, processName);
+  }
+
+  public PipelineResponse initPipeline(
+      String processName,
+      String language,
+      Boolean skipPresent,
+      Boolean returnStatistics,
+      JSONObject jsonBody) {
+    PipelineResponseEntity pre =
+        pipelineManager.startPipeline(processName, language, skipPresent, returnStatistics, jsonBody);
     return addStatusToPipelineResponse(pre, processName);
   }
 

--- a/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
@@ -111,6 +111,21 @@ public class ConceptGraphsService implements ContentService {
     return addStatusToPipelineResponse(pre, processName);
   }
 
+  public PipelineResponse stopPipeline(
+      String processName
+  ) {
+    PipelineResponse pipelineResponse = new PipelineResponse().pipelineId(processName);
+    String stringResponse = pipelineManager.stopPipeline(processName);
+    if (stringResponse.toLowerCase().contains("no thread/process for")) {
+      return pipelineResponse.response(stringResponse).status(PipelineResponseStatus.FAILED);
+    } else if (stringResponse.toLowerCase().contains("find a running step in the pipeline")) {
+      return pipelineResponse.response(stringResponse).status(PipelineResponseStatus.FAILED);
+    } else if (stringResponse.toLowerCase().contains("process will be stopped")) {
+      return pipelineResponse.response(stringResponse).status(PipelineResponseStatus.SUCCESSFUL);
+    }
+    return pipelineResponse.response(stringResponse).status(PipelineResponseStatus.FAILED);
+  }
+
   private PipelineResponse addStatusToPipelineResponse(
       PipelineResponseEntity responseEntity, String processName) {
     if (responseEntity == null) {

--- a/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -107,13 +106,12 @@ public class ConceptGraphsService implements ContentService {
       Boolean returnStatistics,
       JSONObject jsonBody) {
     PipelineResponseEntity pre =
-        pipelineManager.startPipeline(processName, language, skipPresent, returnStatistics, jsonBody);
+        pipelineManager.startPipeline(
+            processName, language, skipPresent, returnStatistics, jsonBody);
     return addStatusToPipelineResponse(pre, processName);
   }
 
-  public PipelineResponse stopPipeline(
-      String processName
-  ) {
+  public PipelineResponse stopPipeline(String processName) {
     PipelineResponse pipelineResponse = new PipelineResponse().pipelineId(processName);
     String stringResponse = pipelineManager.stopPipeline(processName);
     if (stringResponse.toLowerCase().contains("no thread/process for")) {

--- a/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
@@ -82,8 +82,8 @@ public class ConceptGraphsService implements ContentService {
     return pipelineResponse.response(stringResponse).status(PipelineResponseStatus.FAILED);
   }
 
-  public String getPipelineConfig(String processId) {
-    return pipelineManager.getPipelineConfiguration(processId).orElse("{}");
+  public String getPipelineConfig(String processId, String language) {
+    return pipelineManager.getPipelineConfiguration(processId, language).orElse("{}");
   }
 
   public PipelineResponse initPipeline(

--- a/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/ConceptGraphsService.java
@@ -82,6 +82,10 @@ public class ConceptGraphsService implements ContentService {
     return pipelineResponse.response(stringResponse).status(PipelineResponseStatus.FAILED);
   }
 
+  public String getPipelineConfig(String processId) {
+    return pipelineManager.getPipelineConfiguration(processId).orElse("{}");
+  }
+
   public PipelineResponse initPipeline(
       File data,
       File labels,


### PR DESCRIPTION
small additions to adjust to the changed `top-api` and `top-document-query` with regard to getting (standard) pipeline configurations, stopping pipelines and starting them with a `json` request body