### PR TITLE
Fix for large terminologies in concept search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-phenotypic-query</artifactId>
-            <version>0.7.10-SNAPSHOT</version>
+            <version>0.7.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>care.smith.top</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-api</artifactId>
-            <version>0.11.0-SNAPSHOT</version>
+            <version>0.11.1</version>
         </dependency>
         <dependency>
             <groupId>care.smith.top</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-api</artifactId>
-            <version>0.10.1</version>
+            <version>0.11.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>care.smith.top</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-phenotypic-query</artifactId>
-            <version>0.7.8</version>
+            <version>0.7.10-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>care.smith.top</groupId>

--- a/src/main/java/care/smith/top/backend/api/CodeApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/CodeApiDelegateImpl.java
@@ -3,6 +3,7 @@ package care.smith.top.backend.api;
 import care.smith.top.backend.service.OLSCodeService;
 import care.smith.top.model.Code;
 import care.smith.top.model.CodePage;
+import care.smith.top.model.CodeScope;
 import care.smith.top.model.CodeSystemPage;
 import java.net.URI;
 import java.util.List;
@@ -19,8 +20,8 @@ public class CodeApiDelegateImpl implements CodeApiDelegate {
   @Autowired private OLSCodeService codeService;
 
   @Override
-  public ResponseEntity<Code> getCode(URI uri, String codeSystemId, List<String> include) {
-    return ResponseEntity.ok(codeService.getCode(uri, codeSystemId, include));
+  public ResponseEntity<Code> getCode(URI uri, String codeSystemId, CodeScope subtree) {
+    return ResponseEntity.ok(codeService.getCode(uri, codeSystemId, subtree));
   }
 
   @Override

--- a/src/main/java/care/smith/top/backend/api/CodeApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/CodeApiDelegateImpl.java
@@ -20,8 +20,8 @@ public class CodeApiDelegateImpl implements CodeApiDelegate {
   @Autowired private OLSCodeService codeService;
 
   @Override
-  public ResponseEntity<Code> getCode(URI uri, String codeSystemId, CodeScope subtree) {
-    return ResponseEntity.ok(codeService.getCode(uri, codeSystemId, subtree));
+  public ResponseEntity<Code> getCode(URI uri, String codeSystemId, CodeScope scope) {
+    return ResponseEntity.ok(codeService.getCode(uri, codeSystemId, scope));
   }
 
   @Override

--- a/src/main/java/care/smith/top/backend/api/CodeApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/CodeApiDelegateImpl.java
@@ -6,6 +6,8 @@ import care.smith.top.model.CodePage;
 import care.smith.top.model.CodeScope;
 import care.smith.top.model.CodeSystemPage;
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +23,11 @@ public class CodeApiDelegateImpl implements CodeApiDelegate {
 
   @Override
   public ResponseEntity<Code> getCode(URI uri, String codeSystemId, CodeScope scope) {
-    return ResponseEntity.ok(codeService.getCode(uri, codeSystemId, scope));
+    return ResponseEntity.ok(
+        codeService.getCode(
+            URI.create(URLDecoder.decode(uri.toString(), Charset.defaultCharset())),
+            codeSystemId,
+            scope));
   }
 
   @Override

--- a/src/main/java/care/smith/top/backend/configuration/SecurityConfiguration.java
+++ b/src/main/java/care/smith/top/backend/configuration/SecurityConfiguration.java
@@ -25,6 +25,15 @@ public class SecurityConfiguration {
   @Autowired private JwtAuthenticationProvider customAuthenticationProvider;
 
   @Bean
+  public HttpFirewall allowUrlEncodedSlashHttpFirewall() {
+    StrictHttpFirewall firewall = new StrictHttpFirewall();
+    firewall.setAllowUrlEncodedSlash(true);
+    firewall.setAllowUrlEncodedDoubleSlash(true);
+    firewall.setAllowUrlEncodedPercent(true);
+    return firewall;
+  }
+
+  @Bean
   SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.sessionManagement()
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -53,14 +62,5 @@ public class SecurityConfiguration {
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
     return source;
-  }
-  
-  @Bean
-  public HttpFirewall allowUrlEncodedSlashHttpFirewall() {
-    StrictHttpFirewall firewall = new StrictHttpFirewall();
-    firewall.setAllowUrlEncodedSlash(true);
-    firewall.setAllowUrlEncodedDoubleSlash(true);
-    firewall.setAllowUrlEncodedPercent(true);
-    return firewall;
   }
 }

--- a/src/main/java/care/smith/top/backend/configuration/SecurityConfiguration.java
+++ b/src/main/java/care/smith/top/backend/configuration/SecurityConfiguration.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.firewall.HttpFirewall;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -51,5 +53,14 @@ public class SecurityConfiguration {
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
     return source;
+  }
+  
+  @Bean
+  public HttpFirewall allowUrlEncodedSlashHttpFirewall() {
+    StrictHttpFirewall firewall = new StrictHttpFirewall();
+    firewall.setAllowUrlEncodedSlash(true);
+    firewall.setAllowUrlEncodedDoubleSlash(true);
+    firewall.setAllowUrlEncodedPercent(true);
+    return firewall;
   }
 }

--- a/src/main/java/care/smith/top/backend/model/jpa/CodeDao.java
+++ b/src/main/java/care/smith/top/backend/model/jpa/CodeDao.java
@@ -2,8 +2,6 @@ package care.smith.top.backend.model.jpa;
 
 import care.smith.top.model.Code;
 import care.smith.top.model.CodeSystem;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -11,6 +9,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity(name = "code")
 @EntityListeners(AuditingEntityListener.class)
@@ -65,14 +64,6 @@ public class CodeDao {
             .collect(Collectors.toList());
   }
 
-  private CodeDao deepTranslate(Code code) {
-    final CodeDao codeDao = new CodeDao(code);
-    return codeDao.children(
-        Optional.of(code.getChildren()).orElse(Collections.emptyList()).stream()
-            .map(childCode -> deepTranslate(childCode).parent(codeDao))
-            .collect(Collectors.toList()));
-  }
-
   public Code toApiModel() {
     return new Code()
         .code(code)
@@ -82,17 +73,9 @@ public class CodeDao {
         .children(getChildren().stream().map(CodeDao::toApiModel).collect(Collectors.toList()));
   }
 
-  public Long getId() {
-    return id;
-  }
-
   public CodeDao id(@NotNull Long id) {
     this.id = id;
     return this;
-  }
-
-  public CodeDao getParent() {
-    return parent;
   }
 
   public CodeDao parent(@NotNull CodeDao parent) {
@@ -100,17 +83,9 @@ public class CodeDao {
     return this;
   }
 
-  public List<CodeDao> getChildren() {
-    return children;
-  }
-
   public CodeDao children(List<CodeDao> children) {
     this.children = children;
     return this;
-  }
-
-  public String getCode() {
-    return code;
   }
 
   public CodeDao code(@NotNull String code) {
@@ -118,26 +93,14 @@ public class CodeDao {
     return this;
   }
 
-  public String getName() {
-    return name;
-  }
-
   public CodeDao name(String name) {
     this.name = name;
     return this;
   }
 
-  public String getUri() {
-    return uri;
-  }
-
   public CodeDao uri(String uri) {
     this.uri = uri;
     return this;
-  }
-
-  public String getCodeSystemUri() {
-    return codeSystemUri;
   }
 
   public CodeDao codeSystemUri(@NotNull String codeSystemUri) {
@@ -167,5 +130,41 @@ public class CodeDao {
     result = 31 * result + (getUri() != null ? getUri().hashCode() : 0);
     result = 31 * result + getCodeSystemUri().hashCode();
     return result;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public CodeDao getParent() {
+    return parent;
+  }
+
+  public List<CodeDao> getChildren() {
+    return children;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getUri() {
+    return uri;
+  }
+
+  public String getCodeSystemUri() {
+    return codeSystemUri;
+  }
+
+  private CodeDao deepTranslate(Code code) {
+    final CodeDao codeDao = new CodeDao(code);
+    return codeDao.children(
+        Optional.of(code.getChildren()).orElse(Collections.emptyList()).stream()
+            .map(childCode -> deepTranslate(childCode).parent(codeDao))
+            .collect(Collectors.toList()));
   }
 }

--- a/src/main/java/care/smith/top/backend/model/jpa/CodeDao.java
+++ b/src/main/java/care/smith/top/backend/model/jpa/CodeDao.java
@@ -9,10 +9,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity(name = "code")
-@EntityListeners(AuditingEntityListener.class)
 public class CodeDao {
 
   @Id @GeneratedValue private Long id;
@@ -70,7 +68,8 @@ public class CodeDao {
         .uri(uri != null ? URI.create(uri) : null)
         .name(name)
         .codeSystem(new CodeSystem().uri(URI.create(codeSystemUri)))
-        .children(getChildren().stream().map(CodeDao::toApiModel).collect(Collectors.toList()));
+        .children(getChildren().stream().map(CodeDao::toApiModel).collect(Collectors.toList()))
+        .synonyms(Collections.emptyList());
   }
 
   public CodeDao id(@NotNull Long id) {
@@ -163,7 +162,7 @@ public class CodeDao {
   private CodeDao deepTranslate(Code code) {
     final CodeDao codeDao = new CodeDao(code);
     return codeDao.children(
-        Optional.of(code.getChildren()).orElse(Collections.emptyList()).stream()
+        Optional.ofNullable(code.getChildren()).orElse(Collections.emptyList()).stream()
             .map(childCode -> deepTranslate(childCode).parent(codeDao))
             .collect(Collectors.toList()));
   }

--- a/src/main/java/care/smith/top/backend/model/jpa/EntityVersionDao.java
+++ b/src/main/java/care/smith/top/backend/model/jpa/EntityVersionDao.java
@@ -31,7 +31,9 @@ public class EntityVersionDao {
 
   @ElementCollection @OrderColumn private List<LocalisableTextDao> descriptions = null;
 
-  @ElementCollection @OrderColumn private List<CodeDao> codes = null;
+  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderColumn
+  private List<CodeDao> codes = null;
 
   @OneToOne private EntityVersionDao previousVersion;
 

--- a/src/main/java/care/smith/top/backend/repository/jpa/ConceptRepository.java
+++ b/src/main/java/care/smith/top/backend/repository/jpa/ConceptRepository.java
@@ -8,7 +8,10 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.postgresql.core.NativeQuery;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,33 +21,37 @@ public interface ConceptRepository extends EntityRepository {
         new EntityType[] {EntityType.SINGLE_CONCEPT, EntityType.COMPOSITE_CONCEPT});
   }
 
-  default Map<String, Entity> getSubDependencies(
-      Map<String, Entity> concepts, Map<String, Set<String>> dependencies, String repositoryId, Map<String, EntityDao> allOfRepository) {
-    Set<Entity> conceptIter = concepts.values().stream().collect(Collectors.toUnmodifiableSet());
-    if (allOfRepository.isEmpty()) allOfRepository.putAll(getMapOfAll(repositoryId));
-    for (Entity concept : conceptIter) {
-      if (ApiModelMapper.isSingleConcept(concept)) {
-        if (!allOfRepository.containsKey(concept.getId())) continue;
-        EntityDao entityDao = allOfRepository.get(concept.getId());
-        Map<String, Entity> children =
-            entityDao.getSubEntities().stream()
-                .map(EntityDao::toApiModel)
-                .collect(Collectors.toMap(Entity::getId, Function.identity()));
-        if (!children.isEmpty()) {
-          if (dependencies.containsKey(concept.getId())) {
-            dependencies.get(concept.getId()).addAll(children.keySet());
-          } else {
-            dependencies.put(concept.getId(), new HashSet<>(children.keySet()));
-          }
-          concepts.putAll(getSubDependencies(children, dependencies, repositoryId, allOfRepository));
+  @Query(
+          nativeQuery = true,
+          value = "WITH RECURSIVE tree AS (" +
+          " SELECT *, NULL\\:\\:character varying AS parent_id, 0 AS level" +
+          " FROM entity e" +
+          " WHERE id = :entityId" +
+          " UNION" +
+          " SELECT entity.*, super_entities_id AS parent_id, level + 1 AS level" +
+          " FROM entity" +
+          "   JOIN entity_super_entities ON (id = sub_entities_id)" +
+          "   JOIN tree t ON (t.id = super_entities_id)" +
+          ")" +
+          "SELECT *" +
+          "FROM tree")
+  List<EntityDao> getEntityTreeByEntityId(String entityId);
+
+  default void populateEntities(Map<String, Entity> concepts, Map<String, Set<String>> dependencies) {
+    Set<String> conceptIter = concepts.keySet().stream().collect(Collectors.toUnmodifiableSet());
+    for (String conceptId : conceptIter) {
+      for (EntityDao entity : getEntityTreeByEntityId(conceptId)) {
+        String entityId = entity.getId();
+        if (!concepts.containsKey(entityId)) {
+          concepts.put(entityId, entity.toApiModel());
+        }
+        if (dependencies.containsKey(entityId)) {
+          dependencies.get(entityId).addAll(entity.getSubEntities().stream().map(EntityDao::getId).collect(Collectors.toUnmodifiableSet()));
+        }
+        else {
+          dependencies.put(entityId, entity.getSubEntities().stream().map(EntityDao::getId).collect(Collectors.toCollection(LinkedHashSet::new)));
         }
       }
     }
-    return concepts;
-  }
-
-  private Map<String, EntityDao> getMapOfAll(String repositoryId) {
-    return findAllByRepositoryId(repositoryId, Pageable.unpaged()).stream()
-        .collect(Collectors.toMap(EntityDao::getId, Function.identity()));
   }
 }

--- a/src/main/java/care/smith/top/backend/repository/ols/CodeRepository.java
+++ b/src/main/java/care/smith/top/backend/repository/ols/CodeRepository.java
@@ -60,7 +60,11 @@ public class CodeRepository extends OlsRepository {
                     // OLS requires that uri is double URL encoded, so we encode it once and
                     // additionally rely on uriBuilder encoding it for a second time
                     uriBuilder
-                        .pathSegment("ontologies", codeSystemId, "terms", uri.toString())
+                        .pathSegment(
+                            "ontologies",
+                            codeSystemId,
+                            "terms",
+                            URLEncoder.encode(uri.toString(), Charset.defaultCharset()))
                         .build())
             .retrieve()
             .bodyToMono(OLSTerm.class)
@@ -95,6 +99,9 @@ public class CodeRepository extends OlsRepository {
       fillInSubtree(result, scope);
     }
 
+    if (result.getChildren() == null) {
+      result.setChildren(Collections.emptyList());
+    }
     return result;
   }
 
@@ -209,7 +216,8 @@ public class CodeRepository extends OlsRepository {
                         .name(primaryLabel)
                         .uri(URI.create(term.getIri()))
                         .codeSystem(code.getCodeSystem())
-                        .synonyms(term.getSynonyms()));
+                        .synonyms(term.getSynonyms())
+                        .children(Collections.emptyList()));
               });
 
       var paginationInfo = response.getPage();

--- a/src/main/java/care/smith/top/backend/repository/ols/CodeRepository.java
+++ b/src/main/java/care/smith/top/backend/repository/ols/CodeRepository.java
@@ -24,10 +24,10 @@ import reactor.core.publisher.Mono;
 public class CodeRepository extends OlsRepository {
   private static final Logger log = LoggerFactory.getLogger(CodeRepository.class);
 
-  @Value("${spring.paging.page-size:10}")
+  @Value("${coding.suggestions-page-size}")
   private int suggestionsPageSize;
 
-  @Value("500")
+  @Value("${coding.code-children-page-size}")
   private int codeChildrenPageSize;
 
   @Autowired private CodeSystemRepository codeSystemRepository;

--- a/src/main/java/care/smith/top/backend/service/OLSCodeService.java
+++ b/src/main/java/care/smith/top/backend/service/OLSCodeService.java
@@ -4,7 +4,6 @@ import care.smith.top.backend.repository.ols.CodeRepository;
 import care.smith.top.backend.repository.ols.CodeSystemRepository;
 import care.smith.top.backend.repository.ols.OlsRepository;
 import care.smith.top.model.*;
-
 import java.net.URI;
 import java.util.*;
 import java.util.function.Predicate;
@@ -22,11 +21,11 @@ import org.springframework.stereotype.Service;
 @Service
 @Primary
 public class OLSCodeService {
-  @Value("${spring.paging.page-size:10}")
-  private int ontologyPageSize;
-
   @Autowired protected CodeSystemRepository codeSystemRepository;
   @Autowired protected CodeRepository codeRepository;
+
+  @Value("${spring.paging.page-size:10}")
+  private int ontologyPageSize;
 
   @NotNull
   private static Predicate<CodeSystem> filterByName(String name) {

--- a/src/main/java/care/smith/top/backend/service/OLSCodeService.java
+++ b/src/main/java/care/smith/top/backend/service/OLSCodeService.java
@@ -3,10 +3,8 @@ package care.smith.top.backend.service;
 import care.smith.top.backend.repository.ols.CodeRepository;
 import care.smith.top.backend.repository.ols.CodeSystemRepository;
 import care.smith.top.backend.repository.ols.OlsRepository;
-import care.smith.top.model.Code;
-import care.smith.top.model.CodePage;
-import care.smith.top.model.CodeSystem;
-import care.smith.top.model.CodeSystemPage;
+import care.smith.top.model.*;
+
 import java.net.URI;
 import java.util.*;
 import java.util.function.Predicate;
@@ -38,8 +36,8 @@ public class OLSCodeService {
             || cs.getShortName() != null && StringUtils.containsIgnoreCase(cs.getShortName(), name);
   }
 
-  public Code getCode(URI uri, String codeSystemId, List<String> include) {
-    return codeRepository.getCode(uri, codeSystemId);
+  public Code getCode(URI uri, String codeSystemId, CodeScope scope) {
+    return codeRepository.getCode(uri, codeSystemId, scope);
   }
 
   public CodePage getCodes(

--- a/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
@@ -71,11 +71,9 @@ public class DocumentQueryService extends QueryService {
     concepts.add(entity.toApiModel());
 
     Map<String, Set<String>> subDependencies = new HashMap<>();
-    Map<String, EntityDao> allEntities = new HashMap<>();
     Map<String, Entity> conceptMap =
         concepts.stream().collect(Collectors.toMap(Entity::getId, Function.identity()));
-    conceptRepository.getSubDependencies(
-        conceptMap, subDependencies, queryDao.getRepository().getId(), allEntities);
+    conceptRepository.populateEntities(conceptMap, subDependencies);
 
     TextAdapterConfig config = getTextAdapterConfig(query.getDataSource()).orElseThrow();
     QueryResultDao result;

--- a/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
@@ -71,10 +71,11 @@ public class DocumentQueryService extends QueryService {
     concepts.add(entity.toApiModel());
 
     Map<String, Set<String>> subDependencies = new HashMap<>();
+    Map<String, EntityDao> allEntities = new HashMap<>();
     Map<String, Entity> conceptMap =
         concepts.stream().collect(Collectors.toMap(Entity::getId, Function.identity()));
     conceptRepository.getSubDependencies(
-        conceptMap, subDependencies, queryDao.getRepository().getId());
+        conceptMap, subDependencies, queryDao.getRepository().getId(), allEntities);
 
     TextAdapterConfig config = getTextAdapterConfig(query.getDataSource()).orElseThrow();
     QueryResultDao result;

--- a/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
@@ -39,6 +39,9 @@ public class DocumentQueryService extends QueryService {
   @Value("${top.documents.data-source-config-dir:config/data_sources/nlp}")
   private String dataSourceConfigDir;
 
+  @Value("${top.documents.max-term-count:15000}")
+  private Integer maxTermCount;
+
   @Autowired private ConceptRepository conceptRepository;
 
   @Override
@@ -77,31 +80,40 @@ public class DocumentQueryService extends QueryService {
 
     TextAdapterConfig config = getTextAdapterConfig(query.getDataSource()).orElseThrow();
     QueryResultDao result;
-    try {
-      TextAdapter adapter = TextAdapter.getInstance(config);
-      TextFinder finder = new TextFinder(query, conceptMap, subDependencies, adapter);
-      List<DocumentHit> documents = finder.execute();
-      result =
-          new QueryResultDao(
-              queryDao,
-              createdAt,
-              (long) documents.size(),
-              OffsetDateTime.now(),
-              QueryState.FINISHED);
 
-      storeResult(
-          queryDao.getRepository().getOrganisation().getId(),
-          queryDao.getRepository().getId(),
-          queryId.toString(),
-          documents,
-          concepts.toArray(new Concept[0]));
-    } catch (Throwable e) {
-      LOGGER.severe(e.getMessage());
+    if (calculateTermCount(conceptMap, query.getLanguage()) > maxTermCount) {
       result =
           new QueryResultDao(queryDao, createdAt, null, OffsetDateTime.now(), QueryState.FAILED)
-              .message("Cause: " + (e.getMessage() != null ? e.getMessage() : e.toString()));
-    }
+              .message(
+                  String.format(
+                      "Cause: The constructed query consists of more terms than the allowed count of '%s'",
+                      maxTermCount));
+    } else {
+      try {
+        TextAdapter adapter = TextAdapter.getInstance(config);
+        TextFinder finder = new TextFinder(query, conceptMap, subDependencies, adapter);
+        List<DocumentHit> documents = finder.execute();
+        result =
+            new QueryResultDao(
+                queryDao,
+                createdAt,
+                (long) documents.size(),
+                OffsetDateTime.now(),
+                QueryState.FINISHED);
 
+        storeResult(
+            queryDao.getRepository().getOrganisation().getId(),
+            queryDao.getRepository().getId(),
+            queryId.toString(),
+            documents,
+            concepts.toArray(new Concept[0]));
+      } catch (Throwable e) {
+        LOGGER.severe(e.getMessage());
+        result =
+            new QueryResultDao(queryDao, createdAt, null, OffsetDateTime.now(), QueryState.FAILED)
+                .message("Cause: " + (e.getMessage() != null ? e.getMessage() : e.toString()));
+      }
+    }
     queryDao.result(result);
     queryRepository.save(queryDao);
   }
@@ -253,5 +265,22 @@ public class DocumentQueryService extends QueryService {
     csvConverter.write(results, zipStream);
 
     zipStream.close();
+  }
+
+  private int calculateTermCount(Map<String, Entity> conceptMap, String language) {
+    int termCount = 0;
+    for (Entity concept : conceptMap.values()) {
+      termCount +=
+          ((int)
+                  concept.getSynonyms().stream()
+                      .filter(
+                          l -> {
+                            if (language == null) return true;
+                            return language.equals(l.getLang());
+                          })
+                      .count()
+              + 1);
+    }
+    return termCount;
   }
 }

--- a/src/main/java/care/smith/top/backend/service/ols/OLSAutoSuggestion.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSAutoSuggestion.java
@@ -1,5 +1,6 @@
 package care.smith.top.backend.service.ols;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -7,13 +8,13 @@ import java.util.List;
  */
 public class OLSAutoSuggestion {
 
-  private List<String> label_autosuggest;
+  private List<String> label_autosuggest = Collections.emptyList();
 
-  private List<String> label;
+  private List<String> label = Collections.emptyList();
 
-  private List<String> synonym_autosuggest;
+  private List<String> synonym_autosuggest = Collections.emptyList();
 
-  private List<String> synonym;
+  private List<String> synonym = Collections.emptyList();
 
   public List<String> getLabel_autosuggest() {
     return label_autosuggest;

--- a/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenEmbedded.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenEmbedded.java
@@ -1,0 +1,18 @@
+package care.smith.top.backend.service.ols;
+
+import java.util.List;
+
+/**
+ * @author Ralph Schäfermeier
+ */
+public class OLSHierarchicalChildrenEmbedded {
+  private List<OLSTerm> terms;
+  
+  public List<OLSTerm> getTerms() {
+    return terms;
+  }
+  
+  public void setTerms(List<OLSTerm> terms) {
+    this.terms = terms;
+  }
+}

--- a/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenEmbedded.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenEmbedded.java
@@ -7,11 +7,11 @@ import java.util.List;
  */
 public class OLSHierarchicalChildrenEmbedded {
   private List<OLSTerm> terms;
-  
+
   public List<OLSTerm> getTerms() {
     return terms;
   }
-  
+
   public void setTerms(List<OLSTerm> terms) {
     this.terms = terms;
   }

--- a/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenEmbedded.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenEmbedded.java
@@ -1,12 +1,13 @@
 package care.smith.top.backend.service.ols;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
  * @author Ralph Schäfermeier
  */
 public class OLSHierarchicalChildrenEmbedded {
-  private List<OLSTerm> terms;
+  private List<OLSTerm> terms = Collections.emptyList();
 
   public List<OLSTerm> getTerms() {
     return terms;

--- a/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenResponse.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenResponse.java
@@ -6,19 +6,19 @@ package care.smith.top.backend.service.ols;
 public class OLSHierarchicalChildrenResponse {
   private OLSHierarchicalChildrenEmbedded _embedded;
   private OLSPage page;
-  
+
   public OLSHierarchicalChildrenEmbedded get_embedded() {
     return _embedded;
   }
-  
+
   public void set_embedded(OLSHierarchicalChildrenEmbedded _embedded) {
     this._embedded = _embedded;
   }
-  
+
   public OLSPage getPage() {
     return page;
   }
-  
+
   public void setPage(OLSPage page) {
     this.page = page;
   }

--- a/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenResponse.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSHierarchicalChildrenResponse.java
@@ -1,0 +1,25 @@
+package care.smith.top.backend.service.ols;
+
+/**
+ * @author Ralph Schäfermeier
+ */
+public class OLSHierarchicalChildrenResponse {
+  private OLSHierarchicalChildrenEmbedded _embedded;
+  private OLSPage page;
+  
+  public OLSHierarchicalChildrenEmbedded get_embedded() {
+    return _embedded;
+  }
+  
+  public void set_embedded(OLSHierarchicalChildrenEmbedded _embedded) {
+    this._embedded = _embedded;
+  }
+  
+  public OLSPage getPage() {
+    return page;
+  }
+  
+  public void setPage(OLSPage page) {
+    this.page = page;
+  }
+}

--- a/src/main/java/care/smith/top/backend/service/ols/OLSLink.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSLink.java
@@ -1,0 +1,16 @@
+package care.smith.top.backend.service.ols;
+
+/**
+ * @author Ralph Schäfermeier
+ */
+public class OLSLink {
+  private String href;
+  
+  public String getHref() {
+    return href;
+  }
+  
+  public void setHref(String href) {
+    this.href = href;
+  }
+}

--- a/src/main/java/care/smith/top/backend/service/ols/OLSLink.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSLink.java
@@ -5,11 +5,11 @@ package care.smith.top.backend.service.ols;
  */
 public class OLSLink {
   private String href;
-  
+
   public String getHref() {
     return href;
   }
-  
+
   public void setHref(String href) {
     this.href = href;
   }

--- a/src/main/java/care/smith/top/backend/service/ols/OLSLinks.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSLinks.java
@@ -5,11 +5,11 @@ package care.smith.top.backend.service.ols;
  */
 public class OLSLinks {
   private OLSLink hierarchicalChildren;
-  
+
   public OLSLink getHierarchicalChildren() {
     return hierarchicalChildren;
   }
-  
+
   public void setHierarchicalChildren(OLSLink hierarchicalChildren) {
     this.hierarchicalChildren = hierarchicalChildren;
   }

--- a/src/main/java/care/smith/top/backend/service/ols/OLSLinks.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSLinks.java
@@ -1,0 +1,16 @@
+package care.smith.top.backend.service.ols;
+
+/**
+ * @author Ralph Schäfermeier
+ */
+public class OLSLinks {
+  private OLSLink hierarchicalChildren;
+  
+  public OLSLink getHierarchicalChildren() {
+    return hierarchicalChildren;
+  }
+  
+  public void setHierarchicalChildren(OLSLink hierarchicalChildren) {
+    this.hierarchicalChildren = hierarchicalChildren;
+  }
+}

--- a/src/main/java/care/smith/top/backend/service/ols/OLSOntologyEmbedded.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSOntologyEmbedded.java
@@ -4,7 +4,7 @@ package care.smith.top.backend.service.ols;
  * @author ralph
  */
 public class OLSOntologyEmbedded {
-  private OLSOntology[] ontologies;
+  private OLSOntology[] ontologies = new OLSOntology[] {};
 
   public OLSOntology[] getOntologies() {
     return ontologies;

--- a/src/main/java/care/smith/top/backend/service/ols/OLSTerm.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSTerm.java
@@ -15,7 +15,7 @@ public class OLSTerm {
   private String ontology_iri;
   private List<String> synonyms;
   private OLSLinks _links;
-  
+
   public String getIri() {
     return iri;
   }
@@ -79,11 +79,11 @@ public class OLSTerm {
   public void setSynonyms(List<String> synonyms) {
     this.synonyms = synonyms;
   }
-  
+
   public OLSLinks get_links() {
     return _links;
   }
-  
+
   public void set_links(OLSLinks _links) {
     this._links = _links;
   }

--- a/src/main/java/care/smith/top/backend/service/ols/OLSTerm.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSTerm.java
@@ -9,12 +9,13 @@ public class OLSTerm {
   private String iri;
   private String short_form;
   private String label;
-  private String description;
+  private List<String> description;
   private String ontology_name;
   private String ontology_prefix;
   private String ontology_iri;
   private List<String> synonyms;
-
+  private OLSLinks _links;
+  
   public String getIri() {
     return iri;
   }
@@ -39,11 +40,11 @@ public class OLSTerm {
     this.label = label;
   }
 
-  public String getDescription() {
+  public List<String> getDescription() {
     return description;
   }
 
-  public void setDescription(String description) {
+  public void setDescription(List<String> description) {
     this.description = description;
   }
 
@@ -77,5 +78,13 @@ public class OLSTerm {
 
   public void setSynonyms(List<String> synonyms) {
     this.synonyms = synonyms;
+  }
+  
+  public OLSLinks get_links() {
+    return _links;
+  }
+  
+  public void set_links(OLSLinks _links) {
+    this._links = _links;
   }
 }

--- a/src/main/java/care/smith/top/backend/service/ols/OLSTerm.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSTerm.java
@@ -1,5 +1,6 @@
 package care.smith.top.backend.service.ols;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -9,11 +10,11 @@ public class OLSTerm {
   private String iri;
   private String short_form;
   private String label;
-  private List<String> description;
+  private List<String> description = Collections.emptyList();
   private String ontology_name;
   private String ontology_prefix;
   private String ontology_iri;
-  private List<String> synonyms;
+  private List<String> synonyms = Collections.emptyList();
   private OLSLinks _links;
 
   public String getIri() {

--- a/src/main/java/care/smith/top/backend/service/ols/OLSTermsEmbedded.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSTermsEmbedded.java
@@ -1,0 +1,19 @@
+package care.smith.top.backend.service.ols;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Ralph Schäfermeier
+ */
+public class OLSTermsEmbedded {
+  private List<OLSTerm> terms;
+  
+  public List<OLSTerm> getTerms() {
+    return terms;
+  }
+  
+  public void setTerms(List<OLSTerm> terms) {
+    this.terms = terms;
+  }
+}

--- a/src/main/java/care/smith/top/backend/service/ols/OLSTermsEmbedded.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSTermsEmbedded.java
@@ -1,12 +1,13 @@
 package care.smith.top.backend.service.ols;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
  * @author Ralph Schäfermeier
  */
 public class OLSTermsEmbedded {
-  private List<OLSTerm> terms;
+  private List<OLSTerm> terms = Collections.emptyList();
 
   public List<OLSTerm> getTerms() {
     return terms;

--- a/src/main/java/care/smith/top/backend/service/ols/OLSTermsEmbedded.java
+++ b/src/main/java/care/smith/top/backend/service/ols/OLSTermsEmbedded.java
@@ -1,6 +1,5 @@
 package care.smith.top.backend.service.ols;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -8,11 +7,11 @@ import java.util.List;
  */
 public class OLSTermsEmbedded {
   private List<OLSTerm> terms;
-  
+
   public List<OLSTerm> getTerms() {
     return terms;
   }
-  
+
   public void setTerms(List<OLSTerm> terms) {
     this.terms = terms;
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,7 @@ top:
       graphdb:
         username: ${DB_NEO4J_USER:neo4j}
         password: ${DB_NEO4J_PASS:#{null}}
+    max-term-count: 15000
 
 coding:
   terminology-service: ${TERMINOLOGY_SERVICE_ENDPOINT:https://www.ebi.ac.uk/ols4/api}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,3 +80,5 @@ top:
 
 coding:
   terminology-service: ${TERMINOLOGY_SERVICE_ENDPOINT:https://www.ebi.ac.uk/ols4/api}
+  suggestions-page-size: 1000
+  code-children-page-size: 500

--- a/src/main/resources/db/changelog/changesets/202407101044-add-subcodes.yaml
+++ b/src/main/resources/db/changelog/changesets/202407101044-add-subcodes.yaml
@@ -1,18 +1,30 @@
 databaseChangeLog:
   - changeSet:
-      id: 1720604582951-8
+      id: 1720604582951-1
+      author: Ralph Schäfermeier
+      changes:
+        - addColumn:
+            tableName: entity_version_codes
+            columns:
+              - column:
+                  name: codes_id
+                  type: BIGINT
+                  defaultValueSequenceNext: hibernate_sequence
+  - changeSet:
+      id: 1720604582951-2
       author: Ralph Schäfermeier (generated)
       changes:
         - createTable:
+            tableName: code
             columns:
               - column:
-                  autoIncrement: true
                   constraints:
                     nullable: false
                     primaryKey: true
                     primaryKeyName: codePK
                   name: id
                   type: BIGINT
+                  defaultValueSequenceNext: hibernate_sequence
               - column:
                   constraints:
                     nullable: false
@@ -35,45 +47,98 @@ databaseChangeLog:
               - column:
                   name: children_order
                   type: INT
-            tableName: code
   - changeSet:
-      id: 1720604582951-11
+      id: 1720604582951-3
       author: Ralph Schäfermeier (generated)
       changes:
         - addForeignKeyConstraint:
             baseColumnNames: parent_id
             baseTableName: code
-            constraintName: FKlopab3u1y8gn63pdhbhyyiq5f
+            constraintName: FK_code_parentid_code_id
             deferrable: false
             initiallyDeferred: false
             referencedColumnNames: id
             referencedTableName: code
             validate: true
   - changeSet:
-      id: 1720604582951-13
-      author: Ralph Schäfermeier (generated)
+      id: 1720604582951-5
+      author: Ralph Schäfermeier
       changes:
-        - dropColumn:
-            columnName: CODE
-            tableName: ENTITY_VERSION_CODES
+        - sql: insert into code (id, code, code_system_uri, name, uri) select codes_id as id, code, code_system_uri, name, uri from entity_version_codes
+      rollback:
+        - delete:
+            tableName: code
   - changeSet:
-      id: 1720604582951-14
+      id: 1720604582951-4
       author: Ralph Schäfermeier (generated)
       changes:
-        - dropColumn:
-            columnName: CODE_SYSTEM_URI
-            tableName: ENTITY_VERSION_CODES
+        - addForeignKeyConstraint:
+            baseColumnNames: codes_id
+            baseTableName: entity_version_codes
+            constraintName: FK_entityversioncodes_codesid_codes_id
+            deferrable: false
+            initiallyDeferred: false
+            referencedColumnNames: id
+            referencedTableName: code
+            validate: true
   - changeSet:
-      id: 1720604582951-15
+      id: 1720604582951-6
       author: Ralph Schäfermeier (generated)
       changes:
         - dropColumn:
-            columnName: NAME
-            tableName: ENTITY_VERSION_CODES
+            columnName: code
+            tableName: entity_version_codes
+      rollback:
+        - addColumn:
+            tableName: entity_version_codes
+            columns:
+              - column:
+                  name: code
+                  type: VARCHAR(255)
+                  valueComputed: (select c.code from code c where c.id=codes_id)
   - changeSet:
-      id: 1720604582951-16
+      id: 1720604582951-7
       author: Ralph Schäfermeier (generated)
       changes:
         - dropColumn:
-            columnName: URI
-            tableName: ENTITY_VERSION_CODES
+            columnName: code_system_uri
+            tableName: entity_version_codes
+      rollback:
+        - addColumn:
+            tableName: entity_version_codes
+            columns:
+              - column:
+                  name: code_system_uri
+                  type: VARCHAR(255)
+                  valueComputed: (select c.code_system_uri from code c where c.id=codes_id)
+  - changeSet:
+      id: 1720604582951-8
+      author: Ralph Schäfermeier (generated)
+      changes:
+        - dropColumn:
+            columnName: name
+            tableName: entity_version_codes
+      rollback:
+        - addColumn:
+            tableName: entity_version_codes
+            columns:
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+                  valueComputed: (select c.name from code c where c.id=codes_id)
+  - changeSet:
+      id: 1720604582951-9
+      author: Ralph Schäfermeier (generated)
+      changes:
+        - dropColumn:
+            columnName: uri
+            tableName: entity_version_codes
+      rollback:
+        - addColumn:
+            tableName: entity_version_codes
+            columns:
+              - column:
+                  name: uri
+                  type: VARCHAR(255)
+                  valueComputed: (select c.uri from code c where c.id=codes_id)
+

--- a/src/main/resources/db/changelog/changesets/202407101044-add-subcodes.yaml
+++ b/src/main/resources/db/changelog/changesets/202407101044-add-subcodes.yaml
@@ -1,5 +1,6 @@
 databaseChangeLog:
   - changeSet:
+      dbms: postgresql
       id: 1720604582951-1
       author: Ralph Schäfermeier
       changes:
@@ -11,8 +12,21 @@ databaseChangeLog:
                   type: BIGINT
                   defaultValueSequenceNext: hibernate_sequence
   - changeSet:
+      dbms: hsqldb
+      id: 1720604582951-1-test
+      author: Ralph Schäfermeier
+      changes:
+        - addColumn:
+            tableName: entity_version_codes
+            columns:
+              - column:
+                  name: codes_id
+                  type: BIGINT
+                  autoIncrement: true
+  - changeSet:
       id: 1720604582951-2
-      author: Ralph Schäfermeier (generated)
+      dbms: postgresql
+      author: Ralph Schäfermeier
       changes:
         - createTable:
             tableName: code
@@ -25,6 +39,44 @@ databaseChangeLog:
                   name: id
                   type: BIGINT
                   defaultValueSequenceNext: hibernate_sequence
+              - column:
+                  constraints:
+                    nullable: false
+                  name: code
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: code_system_uri
+                  type: VARCHAR(255)
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: uri
+                  type: VARCHAR(255)
+              - column:
+                  name: parent_id
+                  type: BIGINT
+              - column:
+                  name: children_order
+                  type: INT
+  - changeSet:
+      id: 1720604582951-2-test
+      dbms: hsqldb
+      author: Ralph Schäfermeier
+      changes:
+        - createTable:
+            tableName: code
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: codePK
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
               - column:
                   constraints:
                     nullable: false

--- a/src/main/resources/db/changelog/changesets/202407101044-add-subcodes.yaml
+++ b/src/main/resources/db/changelog/changesets/202407101044-add-subcodes.yaml
@@ -1,0 +1,79 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1720604582951-8
+      author: Ralph Schäfermeier (generated)
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: codePK
+                  name: id
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: code
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: code_system_uri
+                  type: VARCHAR(255)
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: uri
+                  type: VARCHAR(255)
+              - column:
+                  name: parent_id
+                  type: BIGINT
+              - column:
+                  name: children_order
+                  type: INT
+            tableName: code
+  - changeSet:
+      id: 1720604582951-11
+      author: Ralph Schäfermeier (generated)
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: parent_id
+            baseTableName: code
+            constraintName: FKlopab3u1y8gn63pdhbhyyiq5f
+            deferrable: false
+            initiallyDeferred: false
+            referencedColumnNames: id
+            referencedTableName: code
+            validate: true
+  - changeSet:
+      id: 1720604582951-13
+      author: Ralph Schäfermeier (generated)
+      changes:
+        - dropColumn:
+            columnName: CODE
+            tableName: ENTITY_VERSION_CODES
+  - changeSet:
+      id: 1720604582951-14
+      author: Ralph Schäfermeier (generated)
+      changes:
+        - dropColumn:
+            columnName: CODE_SYSTEM_URI
+            tableName: ENTITY_VERSION_CODES
+  - changeSet:
+      id: 1720604582951-15
+      author: Ralph Schäfermeier (generated)
+      changes:
+        - dropColumn:
+            columnName: NAME
+            tableName: ENTITY_VERSION_CODES
+  - changeSet:
+      id: 1720604582951-16
+      author: Ralph Schäfermeier (generated)
+      changes:
+        - dropColumn:
+            columnName: URI
+            tableName: ENTITY_VERSION_CODES

--- a/src/main/resources/db/changelog/changesets/202407101044-add-subcodes.yaml
+++ b/src/main/resources/db/changelog/changesets/202407101044-add-subcodes.yaml
@@ -1,7 +1,7 @@
 databaseChangeLog:
   - changeSet:
-      dbms: postgresql
       id: 1720604582951-1
+      dbms: postgresql
       author: Ralph Schäfermeier
       changes:
         - addColumn:
@@ -12,8 +12,8 @@ databaseChangeLog:
                   type: BIGINT
                   defaultValueSequenceNext: hibernate_sequence
   - changeSet:
-      dbms: hsqldb
       id: 1720604582951-1-test
+      dbms: hsqldb
       author: Ralph Schäfermeier
       changes:
         - addColumn:
@@ -28,6 +28,28 @@ databaseChangeLog:
       dbms: postgresql
       author: Ralph Schäfermeier
       changes:
+        - dropDefaultValue:
+            tableName: entity_version_codes
+            columnName: codes_id
+      rollback:
+        - addDefaultValue:
+            tableName: entity_version_codes
+            columnName: codes_id
+            defaultValueSequenceNext: hibernate_sequence
+  - changeSet:
+      id: 1720604582951-2-test
+      dbms: hsqldb
+      author: Ralph Schäfermeier
+      changes:
+        - modifyDataType:
+            tableName: entity_version_codes
+            columnName: codes_id
+            newDataType: BIGINT
+  - changeSet:
+      id: 1720604582951-3
+      dbms: postgresql
+      author: Ralph Schäfermeier
+      changes:
         - createTable:
             tableName: code
             columns:
@@ -62,7 +84,7 @@ databaseChangeLog:
                   name: children_order
                   type: INT
   - changeSet:
-      id: 1720604582951-2-test
+      id: 1720604582951-3-test
       dbms: hsqldb
       author: Ralph Schäfermeier
       changes:
@@ -100,7 +122,7 @@ databaseChangeLog:
                   name: children_order
                   type: INT
   - changeSet:
-      id: 1720604582951-3
+      id: 1720604582951-4
       author: Ralph Schäfermeier (generated)
       changes:
         - addForeignKeyConstraint:
@@ -121,7 +143,7 @@ databaseChangeLog:
         - delete:
             tableName: code
   - changeSet:
-      id: 1720604582951-4
+      id: 1720604582951-6
       author: Ralph Schäfermeier (generated)
       changes:
         - addForeignKeyConstraint:
@@ -134,7 +156,7 @@ databaseChangeLog:
             referencedTableName: code
             validate: true
   - changeSet:
-      id: 1720604582951-6
+      id: 1720604582951-7
       author: Ralph Schäfermeier (generated)
       changes:
         - dropColumn:
@@ -149,7 +171,7 @@ databaseChangeLog:
                   type: VARCHAR(255)
                   valueComputed: (select c.code from code c where c.id=codes_id)
   - changeSet:
-      id: 1720604582951-7
+      id: 1720604582951-8
       author: Ralph Schäfermeier (generated)
       changes:
         - dropColumn:
@@ -164,7 +186,7 @@ databaseChangeLog:
                   type: VARCHAR(255)
                   valueComputed: (select c.code_system_uri from code c where c.id=codes_id)
   - changeSet:
-      id: 1720604582951-8
+      id: 1720604582951-9
       author: Ralph Schäfermeier (generated)
       changes:
         - dropColumn:
@@ -179,7 +201,7 @@ databaseChangeLog:
                   type: VARCHAR(255)
                   valueComputed: (select c.name from code c where c.id=codes_id)
   - changeSet:
-      id: 1720604582951-9
+      id: 1720604582951-10
       author: Ralph Schäfermeier (generated)
       changes:
         - dropColumn:

--- a/src/test/java/care/smith/top/backend/AbstractTest.java
+++ b/src/test/java/care/smith/top/backend/AbstractTest.java
@@ -7,9 +7,11 @@ import care.smith.top.backend.service.OrganisationService;
 import care.smith.top.backend.service.RepositoryService;
 import care.smith.top.backend.service.UserService;
 import care.smith.top.backend.util.ResourceHttpHandler;
+import care.smith.top.backend.util.ResourcePathHttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +44,18 @@ public abstract class AbstractTest {
     olsServer.createContext(
         "/api/ontologies", new ResourceHttpHandler("/ols4_fixtures/ontologies.json"));
     olsServer.createContext("/api/select", new ResourceHttpHandler("/ols4_fixtures/select.json"));
+    olsServer.createContext(
+        "/api/ontologies/test/terms",
+        new ResourcePathHttpHandler(
+            path -> {
+              boolean hierarchicalChildren =
+                  path.getFileName().toString().equals("hierarchicalChildren");
+              Path realPath = hierarchicalChildren ? path.getParent() : path;
+              Path resourceRootPath =
+                  Path.of("/ols4_fixtures", hierarchicalChildren ? "terms_hierarchy" : "terms");
+              Path relativeUriPath = Path.of("/api/ontologies/test/terms").relativize(realPath);
+              return resourceRootPath.resolve(relativeUriPath.toString() + ".json");
+            }));
     olsServer.start();
   }
 

--- a/src/test/java/care/smith/top/backend/EnumTest.java
+++ b/src/test/java/care/smith/top/backend/EnumTest.java
@@ -82,5 +82,8 @@ public class EnumTest {
               RestrictionOperator.GREATER_THAN,
               RestrictionOperator.GREATER_THAN_OR_EQUAL_TO
             });
+
+    assertThat(CodeScope.values())
+        .isEqualTo(new CodeScope[] {CodeScope.SELF, CodeScope.SUBTREE, CodeScope.LEAVES});
   }
 }

--- a/src/test/java/care/smith/top/backend/service/CodeServiceTest.java
+++ b/src/test/java/care/smith/top/backend/service/CodeServiceTest.java
@@ -3,15 +3,86 @@ package care.smith.top.backend.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import care.smith.top.backend.AbstractTest;
-import care.smith.top.model.CodePage;
-import care.smith.top.model.CodeSystemPage;
-import java.util.Collections;
+import care.smith.top.backend.repository.ols.CodeRepository;
+import care.smith.top.backend.repository.ols.CodeSystemRepository;
+import care.smith.top.model.*;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 public class CodeServiceTest extends AbstractTest {
+
+  @Autowired private CodeSystemRepository codeSystemRepository;
+  @Autowired private CodeRepository codeRepository;
+
+  private static final class UriCodeScopeChildCountTuple {
+    URI uri;
+    Integer subtree;
+    Integer leaves;
+
+    UriCodeScopeChildCountTuple(URI uri, Integer subtree, Integer leaves) {
+      this.uri = uri;
+      this.subtree = subtree;
+      this.leaves = leaves;
+    }
+
+    static UriCodeScopeChildCountTuple of(URI uri, Integer subtree, Integer leaves) {
+      return new UriCodeScopeChildCountTuple(uri, subtree, leaves);
+    }
+
+    Integer value(CodeScope scope) {
+      switch (scope) {
+        case SELF:
+          return 0;
+        case SUBTREE:
+          return subtree;
+        case LEAVES:
+          return leaves;
+        default:
+          throw new AssertionError(scope.toString());
+      }
+    }
+  }
+
+  private static final Stream<Arguments> provideTestValuesForSubtrees() {
+    return Stream.of(
+        Arguments.of("test-1", 2, 1),
+        Arguments.of("test-11", 1, 1),
+        Arguments.of("test-2", 8, 5),
+        Arguments.of("test-21", 6, 4),
+        Arguments.of("test-211", 1, 1),
+        Arguments.of("test-212", 4, 3),
+        Arguments.of("test-2121", 1, 1),
+        Arguments.of("test-2122", 1, 1),
+        Arguments.of("test-2123", 1, 1),
+        Arguments.of("test-22", 1, 1),
+        Arguments.of("test-3", 7, 5),
+        Arguments.of("test-31", 4, 3),
+        Arguments.of("test-311", 1, 1),
+        Arguments.of("test-312", 1, 1),
+        Arguments.of("test-313", 1, 1),
+        Arguments.of("test-32", 1, 1),
+        Arguments.of("test-33", 1, 1),
+        Arguments.of("test-4", 5, 4),
+        Arguments.of("test-41", 1, 1),
+        Arguments.of("test-42", 1, 1),
+        Arguments.of("test-43", 1, 1),
+        Arguments.of("test-44", 1, 1),
+        Arguments.of("test-5", 6, 5),
+        Arguments.of("test-51", 1, 1),
+        Arguments.of("test-52", 1, 1),
+        Arguments.of("test-53", 1, 1),
+        Arguments.of("test-54", 1, 1),
+        Arguments.of("test-55", 1, 1));
+  }
+
   @Autowired OLSCodeService codeService;
 
   @Test
@@ -24,5 +95,84 @@ public class CodeServiceTest extends AbstractTest {
   void getCodeSystems() {
     CodeSystemPage codeSystems = codeService.getCodeSystems(null, null, null, 1);
     assertThat(codeSystems).isNotNull().satisfies(cs -> assertThat(cs.getContent()).isNotEmpty());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTestValuesForSubtrees")
+  void createCodesWithSubtrees(String codeName, int expectedSubtreeSize, int expectedLeafCount) {
+    Organisation organisation =
+        organisationService.createOrganisation(new Organisation().id("org"));
+    Repository repository =
+        repositoryService.createRepository(
+            organisation.getId(),
+            new Repository().id("repo").repositoryType(RepositoryType.PHENOTYPE_REPOSITORY),
+            null);
+
+    Arrays.stream(CodeScope.values())
+        .forEach(
+            scope -> {
+              Category category = new Category();
+              Code code =
+                  codeService.getCode(
+                      URI.create("http://top.smith.care/test/terminology#" + codeName),
+                      "test",
+                      scope);
+
+              category
+                  .id(UUID.randomUUID().toString())
+                  .entityType(EntityType.CATEGORY)
+                  .addCodesItem(code);
+
+              assertThat(
+                      entityService.createEntity(
+                          organisation.getId(), repository.getId(), category))
+                  .isNotNull()
+                  .isInstanceOf(Category.class)
+                  .satisfies(
+                      c -> {
+                        assertThat(c.getCodes()).size().isEqualTo(1);
+                        Code codeEntity = c.getCodes().get(0);
+                        fillInCodeSystems(codeEntity);
+
+                        assertThat(codeEntity).isEqualTo(code);
+
+                        switch (scope) {
+                          case SUBTREE:
+                            assertThat(nodeCount(code)).isEqualTo(expectedSubtreeSize);
+                            assertThat(nodeCount(codeEntity)).isEqualTo(expectedSubtreeSize);
+                            break;
+                          case LEAVES:
+                            assertThat(leafCount(code)).isEqualTo(expectedLeafCount);
+                            assertThat(leafCount(codeEntity)).isEqualTo(expectedLeafCount);
+                            break;
+                          case SELF:
+                            assertThat(leafCount(code)).isEqualTo(1);
+                            assertThat(leafCount(codeEntity)).isEqualTo(1);
+                            break;
+                        }
+                      });
+            });
+  }
+
+  private int nodeCount(Code c) {
+    return 1 + c.getChildren().stream().map(child -> nodeCount(child)).reduce(0, Integer::sum);
+  }
+
+  private int leafCount(Code c) {
+    return isLeaf(c)
+        ? 1
+        : c.getChildren().stream().map(child -> leafCount(child)).reduce(0, Integer::sum);
+  }
+
+  private boolean isLeaf(Code c) {
+    return c.getChildren() == null || c.getChildren().size() == 0;
+  }
+
+  private void fillInCodeSystems(Code code) {
+    codeRepository
+        .getCodeSystem(code.getCodeSystem().getUri())
+        .ifPresent(codeSystem -> code.setCodeSystem(codeSystem));
+    Optional.ofNullable(code.getChildren())
+        .ifPresent(children -> children.forEach(child -> fillInCodeSystems(child)));
   }
 }

--- a/src/test/java/care/smith/top/backend/util/ResourcePathHttpHandler.java
+++ b/src/test/java/care/smith/top/backend/util/ResourcePathHttpHandler.java
@@ -1,0 +1,36 @@
+package care.smith.top.backend.util;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.nio.file.Path;
+
+public class ResourcePathHttpHandler implements HttpHandler {
+
+  @FunctionalInterface
+  public interface PathMapper {
+    Path map(Path path);
+  }
+
+  private final PathMapper mapper;
+
+  public ResourcePathHttpHandler(PathMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public void handle(HttpExchange exchange) throws IOException {
+    Path resourcePath = mapper.map(Path.of(exchange.getRequestURI().getRawPath()));
+    try (InputStream resource =
+        ResourcePathHttpHandler.class.getResourceAsStream(resourcePath.toString())) {
+      assert resource != null;
+      byte[] response = resource.readAllBytes();
+      exchange.getResponseHeaders().set("Content-Type", "application/json");
+      exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+      exchange.getResponseBody().write(response);
+    }
+    exchange.close();
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -61,6 +61,7 @@ top:
       documentdb:
         username: ${DB_ELASTIC_USER:elastic}
         password: ${DB_ELASTIC_PASS:#{null}}
+    max-term-count: 15000
 
 coding:
   terminology-service: ${TERMINOLOGY_SERVICE_ENDPOINT:http://localhost:9000/api}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -64,3 +64,5 @@ top:
 
 coding:
   terminology-service: ${TERMINOLOGY_SERVICE_ENDPOINT:http://localhost:9000/api}
+  suggestions-page-size: 1000
+  code-children-page-size: 500

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1.json
@@ -1,0 +1,43 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-1",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : { },
+  "label" : "TEST_#test-1",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : true,
+  "is_root" : true,
+  "short_form" : "TEST_#test-1",
+  "obo_id" : "TEST:#test-1",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1?lang=en"
+    },
+    "children" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1/children"
+    },
+    "descendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1/descendants"
+    },
+    "hierarchicalChildren" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1/hierarchicalChildren"
+    },
+    "hierarchicalDescendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1/hierarchicalDescendants"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-11",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-11" ]
+  },
+  "label" : "test-11",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-11",
+  "obo_id" : "TEST:#test-11",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2.json
@@ -1,0 +1,43 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-2",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : { },
+  "label" : "TEST_#test-2",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : true,
+  "is_root" : true,
+  "short_form" : "TEST_#test-2",
+  "obo_id" : "TEST:#test-2",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2?lang=en"
+    },
+    "children" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2/children"
+    },
+    "descendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2/descendants"
+    },
+    "hierarchicalChildren" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2/hierarchicalChildren"
+    },
+    "hierarchicalDescendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2/hierarchicalDescendants"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21.json
@@ -1,0 +1,60 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-21",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-21" ]
+  },
+  "label" : "test-21",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : true,
+  "is_root" : false,
+  "short_form" : "TEST_#test-21",
+  "obo_id" : "TEST:#test-21",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/jstree"
+    },
+    "children" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/children"
+    },
+    "descendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/descendants"
+    },
+    "hierarchicalChildren" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalChildren"
+    },
+    "hierarchicalDescendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalDescendants"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-211",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-211" ]
+  },
+  "label" : "test-211",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-211",
+  "obo_id" : "TEST:#test-211",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212.json
@@ -1,0 +1,60 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-212",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-212" ]
+  },
+  "label" : "test-212",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : true,
+  "is_root" : false,
+  "short_form" : "TEST_#test-212",
+  "obo_id" : "TEST:#test-212",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/jstree"
+    },
+    "children" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/children"
+    },
+    "descendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/descendants"
+    },
+    "hierarchicalChildren" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalChildren"
+    },
+    "hierarchicalDescendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalDescendants"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-2121",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-2121" ]
+  },
+  "label" : "test-2121",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-2121",
+  "obo_id" : "TEST:#test-2121",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-2122",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-2122" ]
+  },
+  "label" : "test-2122",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-2122",
+  "obo_id" : "TEST:#test-2122",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-2123",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-2123" ]
+  },
+  "label" : "test-2123",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-2123",
+  "obo_id" : "TEST:#test-2123",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-22",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-22" ]
+  },
+  "label" : "test-22",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-22",
+  "obo_id" : "TEST:#test-22",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3.json
@@ -1,0 +1,43 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-3",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : { },
+  "label" : "TEST_#test-3",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : true,
+  "is_root" : true,
+  "short_form" : "TEST_#test-3",
+  "obo_id" : "TEST:#test-3",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3?lang=en"
+    },
+    "children" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3/children"
+    },
+    "descendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3/descendants"
+    },
+    "hierarchicalChildren" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3/hierarchicalChildren"
+    },
+    "hierarchicalDescendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3/hierarchicalDescendants"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31.json
@@ -1,0 +1,60 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-31",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-31" ]
+  },
+  "label" : "test-31",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : true,
+  "is_root" : false,
+  "short_form" : "TEST_#test-31",
+  "obo_id" : "TEST:#test-31",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/jstree"
+    },
+    "children" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/children"
+    },
+    "descendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/descendants"
+    },
+    "hierarchicalChildren" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalChildren"
+    },
+    "hierarchicalDescendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalDescendants"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-311",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-311" ]
+  },
+  "label" : "test-311",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-311",
+  "obo_id" : "TEST:#test-311",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-312",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-312" ]
+  },
+  "label" : "test-312",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-312",
+  "obo_id" : "TEST:#test-312",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-313",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-313" ]
+  },
+  "label" : "test-313",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-313",
+  "obo_id" : "TEST:#test-313",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-32",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-32" ]
+  },
+  "label" : "test-32",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-32",
+  "obo_id" : "TEST:#test-32",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-33",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-33" ]
+  },
+  "label" : "test-33",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-33",
+  "obo_id" : "TEST:#test-33",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4.json
@@ -1,0 +1,43 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-4",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : { },
+  "label" : "TEST_#test-4",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : true,
+  "is_root" : true,
+  "short_form" : "TEST_#test-4",
+  "obo_id" : "TEST:#test-4",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4?lang=en"
+    },
+    "children" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4/children"
+    },
+    "descendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4/descendants"
+    },
+    "hierarchicalChildren" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4/hierarchicalChildren"
+    },
+    "hierarchicalDescendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4/hierarchicalDescendants"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-41",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-41" ]
+  },
+  "label" : "test-41",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-41",
+  "obo_id" : "TEST:#test-41",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-42",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-42" ]
+  },
+  "label" : "test-42",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-42",
+  "obo_id" : "TEST:#test-42",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-43",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-43" ]
+  },
+  "label" : "test-43",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-43",
+  "obo_id" : "TEST:#test-43",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-44",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-44" ]
+  },
+  "label" : "test-44",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-44",
+  "obo_id" : "TEST:#test-44",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5.json
@@ -1,0 +1,43 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-5",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : { },
+  "label" : "TEST_#test-5",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : true,
+  "is_root" : true,
+  "short_form" : "TEST_#test-5",
+  "obo_id" : "TEST:#test-5",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5?lang=en"
+    },
+    "children" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5/children"
+    },
+    "descendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5/descendants"
+    },
+    "hierarchicalChildren" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5/hierarchicalChildren"
+    },
+    "hierarchicalDescendants" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5/hierarchicalDescendants"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-51",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-51" ]
+  },
+  "label" : "test-51",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-51",
+  "obo_id" : "TEST:#test-51",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-52",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-52" ]
+  },
+  "label" : "test-52",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-52",
+  "obo_id" : "TEST:#test-52",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-53",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-53" ]
+  },
+  "label" : "test-53",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-53",
+  "obo_id" : "TEST:#test-53",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-54",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-54" ]
+  },
+  "label" : "test-54",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-54",
+  "obo_id" : "TEST:#test-54",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55.json
+++ b/src/test/resources/ols4_fixtures/terms/http%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55.json
@@ -1,0 +1,48 @@
+{
+  "iri" : "https://top.smith.care/test/terminology#test-55",
+  "lang" : "en",
+  "description" : [ ],
+  "synonyms" : [ ],
+  "annotation" : {
+    "prefLabel" : [ "test-55" ]
+  },
+  "label" : "test-55",
+  "ontology_name" : "test",
+  "ontology_prefix" : "TEST",
+  "ontology_iri" : "https://top.smith.care/test/terminology",
+  "is_obsolete" : false,
+  "term_replaced_by" : null,
+  "is_defining_ontology" : true,
+  "has_children" : false,
+  "is_root" : false,
+  "short_form" : "TEST_#test-55",
+  "obo_id" : "TEST:#test-55",
+  "in_subset" : null,
+  "obo_definition_citation" : null,
+  "obo_xref" : null,
+  "obo_synonym" : null,
+  "is_preferred_root" : false,
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55?lang=en"
+    },
+    "parents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/parents"
+    },
+    "ancestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/ancestors"
+    },
+    "hierarchicalParents" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/hierarchicalParents"
+    },
+    "hierarchicalAncestors" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/hierarchicalAncestors"
+    },
+    "jstree" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/jstree"
+    },
+    "graph" : {
+      "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/graph"
+    }
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1.json
@@ -1,0 +1,63 @@
+{
+  "_embedded" : {
+    "terms" : [ {
+      "iri" : "https://top.smith.care/test/terminology#test-11",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-11" ]
+      },
+      "label" : "test-11",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-11",
+      "obo_id" : "TEST:#test-11",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/graph"
+        }
+      }
+    } ]
+  },
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-1/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 1,
+    "totalPages" : 1,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-11/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2.json
@@ -1,0 +1,122 @@
+{
+  "_embedded" : {
+    "terms" : [ {
+      "iri" : "https://top.smith.care/test/terminology#test-22",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-22" ]
+      },
+      "label" : "test-22",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-22",
+      "obo_id" : "TEST:#test-22",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-21",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-21" ]
+      },
+      "label" : "test-21",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : true,
+      "is_root" : false,
+      "short_form" : "TEST_#test-21",
+      "obo_id" : "TEST:#test-21",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/jstree"
+        },
+        "children" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/children"
+        },
+        "descendants" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/descendants"
+        },
+        "hierarchicalChildren" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalChildren"
+        },
+        "hierarchicalDescendants" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalDescendants"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/graph"
+        }
+      }
+    } ]
+  },
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 2,
+    "totalPages" : 1,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21.json
@@ -1,0 +1,122 @@
+{
+  "_embedded" : {
+    "terms" : [ {
+      "iri" : "https://top.smith.care/test/terminology#test-212",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-212" ]
+      },
+      "label" : "test-212",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : true,
+      "is_root" : false,
+      "short_form" : "TEST_#test-212",
+      "obo_id" : "TEST:#test-212",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/jstree"
+        },
+        "children" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/children"
+        },
+        "descendants" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/descendants"
+        },
+        "hierarchicalChildren" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalChildren"
+        },
+        "hierarchicalDescendants" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalDescendants"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-211",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-211" ]
+      },
+      "label" : "test-211",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-211",
+      "obo_id" : "TEST:#test-211",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/graph"
+        }
+      }
+    } ]
+  },
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-21/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 2,
+    "totalPages" : 1,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-211/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212.json
@@ -1,0 +1,157 @@
+{
+  "_embedded" : {
+    "terms" : [ {
+      "iri" : "https://top.smith.care/test/terminology#test-2123",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-2123" ]
+      },
+      "label" : "test-2123",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-2123",
+      "obo_id" : "TEST:#test-2123",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-2122",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-2122" ]
+      },
+      "label" : "test-2122",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-2122",
+      "obo_id" : "TEST:#test-2122",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-2121",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-2121" ]
+      },
+      "label" : "test-2121",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-2121",
+      "obo_id" : "TEST:#test-2121",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/graph"
+        }
+      }
+    } ]
+  },
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-212/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 3,
+    "totalPages" : 1,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2121/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2122/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-2123/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-22/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3.json
@@ -1,0 +1,169 @@
+{
+  "_embedded" : {
+    "terms" : [ {
+      "iri" : "https://top.smith.care/test/terminology#test-33",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-33" ]
+      },
+      "label" : "test-33",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-33",
+      "obo_id" : "TEST:#test-33",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-32",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-32" ]
+      },
+      "label" : "test-32",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-32",
+      "obo_id" : "TEST:#test-32",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-31",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-31" ]
+      },
+      "label" : "test-31",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : true,
+      "is_root" : false,
+      "short_form" : "TEST_#test-31",
+      "obo_id" : "TEST:#test-31",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/jstree"
+        },
+        "children" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/children"
+        },
+        "descendants" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/descendants"
+        },
+        "hierarchicalChildren" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalChildren"
+        },
+        "hierarchicalDescendants" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalDescendants"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/graph"
+        }
+      }
+    } ]
+  },
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-3/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 3,
+    "totalPages" : 1,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31.json
@@ -1,0 +1,157 @@
+{
+  "_embedded" : {
+    "terms" : [ {
+      "iri" : "https://top.smith.care/test/terminology#test-313",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-313" ]
+      },
+      "label" : "test-313",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-313",
+      "obo_id" : "TEST:#test-313",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-312",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-312" ]
+      },
+      "label" : "test-312",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-312",
+      "obo_id" : "TEST:#test-312",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-311",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-311" ]
+      },
+      "label" : "test-311",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-311",
+      "obo_id" : "TEST:#test-311",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/graph"
+        }
+      }
+    } ]
+  },
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-31/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 3,
+    "totalPages" : 1,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-311/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-312/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-313/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-32/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-33/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4.json
@@ -1,0 +1,204 @@
+{
+  "_embedded" : {
+    "terms" : [ {
+      "iri" : "https://top.smith.care/test/terminology#test-44",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-44" ]
+      },
+      "label" : "test-44",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-44",
+      "obo_id" : "TEST:#test-44",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-43",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-43" ]
+      },
+      "label" : "test-43",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-43",
+      "obo_id" : "TEST:#test-43",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-42",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-42" ]
+      },
+      "label" : "test-42",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-42",
+      "obo_id" : "TEST:#test-42",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-41",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-41" ]
+      },
+      "label" : "test-41",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-41",
+      "obo_id" : "TEST:#test-41",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/graph"
+        }
+      }
+    } ]
+  },
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-4/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 4,
+    "totalPages" : 1,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-41/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-42/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-43/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-44/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5.json
@@ -1,0 +1,251 @@
+{
+  "_embedded" : {
+    "terms" : [ {
+      "iri" : "https://top.smith.care/test/terminology#test-55",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-55" ]
+      },
+      "label" : "test-55",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-55",
+      "obo_id" : "TEST:#test-55",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-54",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-54" ]
+      },
+      "label" : "test-54",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-54",
+      "obo_id" : "TEST:#test-54",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-53",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-53" ]
+      },
+      "label" : "test-53",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-53",
+      "obo_id" : "TEST:#test-53",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-52",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-52" ]
+      },
+      "label" : "test-52",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-52",
+      "obo_id" : "TEST:#test-52",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/graph"
+        }
+      }
+    }, {
+      "iri" : "https://top.smith.care/test/terminology#test-51",
+      "lang" : "en",
+      "description" : [ ],
+      "synonyms" : [ ],
+      "annotation" : {
+        "prefLabel" : [ "test-51" ]
+      },
+      "label" : "test-51",
+      "ontology_name" : "test",
+      "ontology_prefix" : "TEST",
+      "ontology_iri" : "https://top.smith.care/test/terminology",
+      "is_obsolete" : false,
+      "term_replaced_by" : null,
+      "is_defining_ontology" : true,
+      "has_children" : false,
+      "is_root" : false,
+      "short_form" : "TEST_#test-51",
+      "obo_id" : "TEST:#test-51",
+      "in_subset" : null,
+      "obo_definition_citation" : null,
+      "obo_xref" : null,
+      "obo_synonym" : null,
+      "is_preferred_root" : false,
+      "_links" : {
+        "self" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51?lang=en"
+        },
+        "parents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/parents"
+        },
+        "ancestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/ancestors"
+        },
+        "hierarchicalParents" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/hierarchicalParents"
+        },
+        "hierarchicalAncestors" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/hierarchicalAncestors"
+        },
+        "jstree" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/jstree"
+        },
+        "graph" : {
+          "href" : "http://localhost:9000/api/ontologies/test/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/graph"
+        }
+      }
+    } ]
+  },
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-5/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 5,
+    "totalPages" : 1,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-51/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-52/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-53/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-54/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}

--- a/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55.json
+++ b/src/test/resources/ols4_fixtures/terms_hierarchy/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55.json
@@ -1,0 +1,13 @@
+{
+  "_links" : {
+    "self" : {
+      "href" : "http://localhost:9000/api/ontologies/TEST/terms/https%253A%252F%252Ftop.smith.care%252Ftest%252Fterminology%2523test-55/hierarchicalChildren?page=0&size=500"
+    }
+  },
+  "page" : {
+    "size" : 500,
+    "totalElements" : 0,
+    "totalPages" : 0,
+    "number" : 0
+  }
+}


### PR DESCRIPTION
This PR solves the problem that queries slowed down due to a disadvantageous implementation of a recursive call to the DB when gathering all entities for a query. The recursion is now done with a custom SQL query.
Secondly, a max term count check was introduced that rejects queries which terms surpass a specific value (slightly experimentally deduced but anecdotal value of 15.000 at the moment).