### PR TITLE
Fix for large terminologies concept search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-api</artifactId>
-            <version>0.11.1</version>
+            <version>0.10.1</version>
         </dependency>
         <dependency>
             <groupId>care.smith.top</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>care.smith.top</groupId>
             <artifactId>top-api</artifactId>
-            <version>0.10.1</version>
+            <version>0.11.1</version>
         </dependency>
         <dependency>
             <groupId>care.smith.top</groupId>

--- a/src/main/java/care/smith/top/backend/repository/jpa/ConceptRepository.java
+++ b/src/main/java/care/smith/top/backend/repository/jpa/ConceptRepository.java
@@ -8,7 +8,10 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.postgresql.core.NativeQuery;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,33 +21,37 @@ public interface ConceptRepository extends EntityRepository {
         new EntityType[] {EntityType.SINGLE_CONCEPT, EntityType.COMPOSITE_CONCEPT});
   }
 
-  default Map<String, Entity> getSubDependencies(
-      Map<String, Entity> concepts, Map<String, Set<String>> dependencies, String repositoryId, Map<String, EntityDao> allOfRepository) {
-    Set<Entity> conceptIter = concepts.values().stream().collect(Collectors.toUnmodifiableSet());
-    if (allOfRepository.isEmpty()) allOfRepository.putAll(getMapOfAll(repositoryId));
-    for (Entity concept : conceptIter) {
-      if (ApiModelMapper.isSingleConcept(concept)) {
-        if (!allOfRepository.containsKey(concept.getId())) continue;
-        EntityDao entityDao = allOfRepository.get(concept.getId());
-        Map<String, Entity> children =
-            entityDao.getSubEntities().stream()
-                .map(EntityDao::toApiModel)
-                .collect(Collectors.toMap(Entity::getId, Function.identity()));
-        if (!children.isEmpty()) {
-          if (dependencies.containsKey(concept.getId())) {
-            dependencies.get(concept.getId()).addAll(children.keySet());
-          } else {
-            dependencies.put(concept.getId(), new HashSet<>(children.keySet()));
-          }
-          concepts.putAll(getSubDependencies(children, dependencies, repositoryId, allOfRepository));
+  @Query(
+          nativeQuery = true,
+          value = "WITH RECURSIVE tree AS (" +
+          " SELECT *, NULL\\:\\:character varying AS parent_id, 0 AS level" +
+          " FROM entity e" +
+          " WHERE id = :entityId" +
+          " UNION" +
+          " SELECT entity.*, super_entities_id AS parent_id, level + 1 AS level" +
+          " FROM entity" +
+          "   JOIN entity_super_entities ON (id = sub_entities_id)" +
+          "   JOIN tree t ON (t.id = super_entities_id)" +
+          ")" +
+          "SELECT *" +
+          "FROM tree")
+  List<EntityDao> getEntityTreeByEntityId(String entityId);
+
+  default void populateEntities(Map<String, Entity> concepts, Map<String, Set<String>> dependencies) {
+    Set<String> conceptIter = concepts.keySet().stream().collect(Collectors.toUnmodifiableSet());
+    for (String conceptId : conceptIter) {
+      for (EntityDao entity : getEntityTreeByEntityId(conceptId)) {
+        String entityId = entity.getId();
+        if (!concepts.containsKey(entityId)) {
+          concepts.put(entityId, entity.toApiModel());
+        }
+        if (dependencies.containsKey(entityId)) {
+          dependencies.get(entityId).addAll(entity.getSubEntities().stream().map(EntityDao::getId).collect(Collectors.toUnmodifiableSet()));
+        }
+        else {
+          dependencies.put(entityId, entity.getSubEntities().stream().map(EntityDao::getId).collect(Collectors.toCollection(LinkedHashSet::new)));
         }
       }
     }
-    return concepts;
-  }
-
-  private Map<String, EntityDao> getMapOfAll(String repositoryId) {
-    return findAllByRepositoryId(repositoryId, Pageable.unpaged()).stream()
-        .collect(Collectors.toMap(EntityDao::getId, Function.identity()));
   }
 }

--- a/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
@@ -71,11 +71,9 @@ public class DocumentQueryService extends QueryService {
     concepts.add(entity.toApiModel());
 
     Map<String, Set<String>> subDependencies = new HashMap<>();
-    Map<String, EntityDao> allEntities = new HashMap<>();
     Map<String, Entity> conceptMap =
         concepts.stream().collect(Collectors.toMap(Entity::getId, Function.identity()));
-    conceptRepository.getSubDependencies(
-        conceptMap, subDependencies, queryDao.getRepository().getId(), allEntities);
+    conceptRepository.populateEntities(conceptMap, subDependencies);
 
     TextAdapterConfig config = getTextAdapterConfig(query.getDataSource()).orElseThrow();
     QueryResultDao result;

--- a/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
@@ -71,10 +71,11 @@ public class DocumentQueryService extends QueryService {
     concepts.add(entity.toApiModel());
 
     Map<String, Set<String>> subDependencies = new HashMap<>();
+    Map<String, EntityDao> allEntities = new HashMap<>();
     Map<String, Entity> conceptMap =
         concepts.stream().collect(Collectors.toMap(Entity::getId, Function.identity()));
     conceptRepository.getSubDependencies(
-        conceptMap, subDependencies, queryDao.getRepository().getId());
+        conceptMap, subDependencies, queryDao.getRepository().getId(), allEntities);
 
     TextAdapterConfig config = getTextAdapterConfig(query.getDataSource()).orElseThrow();
     QueryResultDao result;

--- a/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
+++ b/src/main/java/care/smith/top/backend/service/nlp/DocumentQueryService.java
@@ -39,6 +39,9 @@ public class DocumentQueryService extends QueryService {
   @Value("${top.documents.data-source-config-dir:config/data_sources/nlp}")
   private String dataSourceConfigDir;
 
+  @Value("${top.documents.max-term-count:15000}")
+  private Integer maxTermCount;
+
   @Autowired private ConceptRepository conceptRepository;
 
   @Override
@@ -77,31 +80,40 @@ public class DocumentQueryService extends QueryService {
 
     TextAdapterConfig config = getTextAdapterConfig(query.getDataSource()).orElseThrow();
     QueryResultDao result;
-    try {
-      TextAdapter adapter = TextAdapter.getInstance(config);
-      TextFinder finder = new TextFinder(query, conceptMap, subDependencies, adapter);
-      List<DocumentHit> documents = finder.execute();
-      result =
-          new QueryResultDao(
-              queryDao,
-              createdAt,
-              (long) documents.size(),
-              OffsetDateTime.now(),
-              QueryState.FINISHED);
 
-      storeResult(
-          queryDao.getRepository().getOrganisation().getId(),
-          queryDao.getRepository().getId(),
-          queryId.toString(),
-          documents,
-          concepts.toArray(new Concept[0]));
-    } catch (Throwable e) {
-      LOGGER.severe(e.getMessage());
+    if (calculateTermCount(conceptMap, query.getLanguage()) > maxTermCount) {
       result =
           new QueryResultDao(queryDao, createdAt, null, OffsetDateTime.now(), QueryState.FAILED)
-              .message("Cause: " + (e.getMessage() != null ? e.getMessage() : e.toString()));
-    }
+              .message(
+                  String.format(
+                      "Cause: The constructed query consists of more terms than the allowed count of '%s'",
+                      maxTermCount));
+    } else {
+      try {
+        TextAdapter adapter = TextAdapter.getInstance(config);
+        TextFinder finder = new TextFinder(query, conceptMap, subDependencies, adapter);
+        List<DocumentHit> documents = finder.execute();
+        result =
+            new QueryResultDao(
+                queryDao,
+                createdAt,
+                (long) documents.size(),
+                OffsetDateTime.now(),
+                QueryState.FINISHED);
 
+        storeResult(
+            queryDao.getRepository().getOrganisation().getId(),
+            queryDao.getRepository().getId(),
+            queryId.toString(),
+            documents,
+            concepts.toArray(new Concept[0]));
+      } catch (Throwable e) {
+        LOGGER.severe(e.getMessage());
+        result =
+            new QueryResultDao(queryDao, createdAt, null, OffsetDateTime.now(), QueryState.FAILED)
+                .message("Cause: " + (e.getMessage() != null ? e.getMessage() : e.toString()));
+      }
+    }
     queryDao.result(result);
     queryRepository.save(queryDao);
   }
@@ -253,5 +265,22 @@ public class DocumentQueryService extends QueryService {
     csvConverter.write(results, zipStream);
 
     zipStream.close();
+  }
+
+  private int calculateTermCount(Map<String, Entity> conceptMap, String language) {
+    int termCount = 0;
+    for (Entity concept : conceptMap.values()) {
+      termCount +=
+          ((int)
+                  concept.getSynonyms().stream()
+                      .filter(
+                          l -> {
+                            if (language == null) return true;
+                            return language.equals(l.getLang());
+                          })
+                      .count()
+              + 1);
+    }
+    return termCount;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,7 @@ top:
       graphdb:
         username: ${DB_NEO4J_USER:neo4j}
         password: ${DB_NEO4J_PASS:#{null}}
+    max-term-count: 15000
 
 coding:
   terminology-service: ${TERMINOLOGY_SERVICE_ENDPOINT:https://www.ebi.ac.uk/ols4/api}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -61,6 +61,7 @@ top:
       documentdb:
         username: ${DB_ELASTIC_USER:elastic}
         password: ${DB_ELASTIC_PASS:#{null}}
+    max-term-count: 15000
 
 coding:
   terminology-service: ${TERMINOLOGY_SERVICE_ENDPOINT:http://localhost:9000/api}


### PR DESCRIPTION
I tried to remove the mentioned commits in the previous branch, but it seemed way to complicated. New branch that just omits these commits.
> This PR solves the problem that queries slowed down due to a disadvantageous implementation of a recursive call to the DB when gathering all entities for a query. The recursion is now done with a custom SQL query.
> Secondly, a max term count check was introduced that rejects queries which terms surpass a specific value (slightly experimentally deduced but anecdotal value of 15.000 at the moment).