### PR TITLE
Add better recovery after TS connection problems

### DIFF
--- a/src/main/java/care/smith/top/backend/api/CodeApiDelegateImpl.java
+++ b/src/main/java/care/smith/top/backend/api/CodeApiDelegateImpl.java
@@ -1,5 +1,6 @@
 package care.smith.top.backend.api;
 
+import care.smith.top.backend.repository.ols.OlsConnectionException;
 import care.smith.top.backend.service.OLSCodeService;
 import care.smith.top.model.Code;
 import care.smith.top.model.CodePage;
@@ -33,18 +34,30 @@ public class CodeApiDelegateImpl implements CodeApiDelegate {
   @Override
   public ResponseEntity<CodePage> getCodes(
       List<String> include, String label, List<String> codeSystemIds, Integer page) {
-    return ResponseEntity.ok(codeService.getCodes(include, label, codeSystemIds, page));
+    try {
+      return ResponseEntity.ok(codeService.getCodes(include, label, codeSystemIds, page));
+    } catch (OlsConnectionException e) {
+      return ResponseEntity.internalServerError().build();
+    }
   }
 
   @Override
   public ResponseEntity<CodePage> getCodeSuggestions(
       List<String> include, String term, List<String> codeSystemIds, Integer page) {
-    return ResponseEntity.ok(codeService.getCodeSuggestions(include, term, codeSystemIds, page));
+    try {
+      return ResponseEntity.ok(codeService.getCodeSuggestions(include, term, codeSystemIds, page));
+    } catch (OlsConnectionException e) {
+      return ResponseEntity.internalServerError().build();
+    }
   }
 
   @Override
   public ResponseEntity<CodeSystemPage> getCodeSystems(
       List<String> include, URI uri, String name, Integer page) {
-    return ResponseEntity.ok(codeService.getCodeSystems(include, uri, name, page));
+    try {
+      return ResponseEntity.ok(codeService.getCodeSystems(include, uri, name, page));
+    } catch (Exception e) {
+      return ResponseEntity.internalServerError().build();
+    }
   }
 }

--- a/src/main/java/care/smith/top/backend/repository/ols/CodeSystemRepository.java
+++ b/src/main/java/care/smith/top/backend/repository/ols/CodeSystemRepository.java
@@ -15,7 +15,7 @@ public class CodeSystemRepository extends OlsRepository {
   private static final Logger LOGGER = Logger.getLogger(CodeSystemRepository.class.getName());
 
   @Cacheable("olsOntologies")
-  public Map<URI, CodeSystem> getAllCodeSystems() {
+  public Map<URI, CodeSystem> getAllCodeSystems() throws OlsConnectionException {
     try {
       OLSOntologiesResponse response =
           terminologyService
@@ -45,8 +45,8 @@ public class CodeSystemRepository extends OlsRepository {
               Collectors.toMap(
                   CodeSystem::getUri, Function.identity(), (existing, replacement) -> existing));
     } catch (Exception e) {
-      LOGGER.severe(e.getMessage());
+      LOGGER.severe("Could not retrieve code systems from terminology server: " + e.getMessage());
+      throw new OlsConnectionException(e);
     }
-    return new HashMap<>();
   }
 }

--- a/src/main/java/care/smith/top/backend/repository/ols/OlsConnectionException.java
+++ b/src/main/java/care/smith/top/backend/repository/ols/OlsConnectionException.java
@@ -1,0 +1,7 @@
+package care.smith.top.backend.repository.ols;
+
+public class OlsConnectionException extends Exception {
+  public OlsConnectionException(Exception cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/care/smith/top/backend/service/OLSCodeService.java
+++ b/src/main/java/care/smith/top/backend/service/OLSCodeService.java
@@ -2,6 +2,7 @@ package care.smith.top.backend.service;
 
 import care.smith.top.backend.repository.ols.CodeRepository;
 import care.smith.top.backend.repository.ols.CodeSystemRepository;
+import care.smith.top.backend.repository.ols.OlsConnectionException;
 import care.smith.top.backend.repository.ols.OlsRepository;
 import care.smith.top.model.*;
 import java.net.URI;
@@ -40,12 +41,14 @@ public class OLSCodeService {
   }
 
   public CodePage getCodes(
-      List<String> include, String label, List<String> codeSystemIds, Integer page) {
+      List<String> include, String label, List<String> codeSystemIds, Integer page)
+      throws OlsConnectionException {
     return codeRepository.getCodes(label, codeSystemIds, page, OlsRepository.SEARCH_METHOD.SEARCH);
   }
 
   public CodePage getCodeSuggestions(
-      List<String> include, String label, List<String> codeSystemIds, Integer page) {
+      List<String> include, String label, List<String> codeSystemIds, Integer page)
+      throws OlsConnectionException {
     return codeRepository.getCodes(label, codeSystemIds, page, OlsRepository.SEARCH_METHOD.SUGGEST);
   }
 
@@ -61,7 +64,8 @@ public class OLSCodeService {
    * @param page Requested page
    * @return A {@link CodeSystemPage} containing matching code systems.
    */
-  public CodeSystemPage getCodeSystems(List<String> include, URI uri, String name, Integer page) {
+  public CodeSystemPage getCodeSystems(List<String> include, URI uri, String name, Integer page)
+      throws OlsConnectionException {
     int requestedPage = page == null ? 1 : page;
     int skipCount = (requestedPage - 1) * ontologyPageSize;
 

--- a/src/test/java/care/smith/top/backend/service/CodeServiceTest.java
+++ b/src/test/java/care/smith/top/backend/service/CodeServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import care.smith.top.backend.AbstractTest;
 import care.smith.top.backend.repository.ols.CodeRepository;
 import care.smith.top.backend.repository.ols.CodeSystemRepository;
+import care.smith.top.backend.repository.ols.OlsConnectionException;
 import care.smith.top.model.*;
 import java.net.URI;
 import java.util.*;
@@ -86,13 +87,13 @@ public class CodeServiceTest extends AbstractTest {
   @Autowired OLSCodeService codeService;
 
   @Test
-  void getSuggestions() {
+  void getSuggestions() throws OlsConnectionException {
     CodePage suggestions = codeService.getCodeSuggestions(null, "term", Collections.emptyList(), 1);
     assertThat(suggestions).isNotNull().satisfies(s -> assertThat(s.getContent()).isNotEmpty());
   }
 
   @Test
-  void getCodeSystems() {
+  void getCodeSystems() throws OlsConnectionException {
     CodeSystemPage codeSystems = codeService.getCodeSystems(null, null, null, 1);
     assertThat(codeSystems).isNotNull().satisfies(cs -> assertThat(cs.getContent()).isNotEmpty());
   }


### PR DESCRIPTION
This PR adds better recovery after failed attempts to connect to the external terminology service. In particular, once an attempt to retrieve the list of available code systems from the terminology service has failed, the result from the failed attempt (an empty code system list) is not cached anymore. Subsequent attempts will now trigger another attempt to fetch the list from the terminology server until it succeeds.